### PR TITLE
Fix: Incorrect test steps for incorrect-inputs spec

### DIFF
--- a/specs/web/swapping/incorrect-inputs.spec.ts
+++ b/specs/web/swapping/incorrect-inputs.spec.ts
@@ -21,8 +21,8 @@ suite({
     {
       name: "with an exceeds balance",
       test: async ({ web }) => {
+        await web.swap.fillForm({ fromAmount: "100" });
         await web.swap.continueToConfirmation();
-        await web.swap.fillForm({ fromAmount: "5" });
         expect(await web.swap.isAmountExceedValidationThere()).toBeTruthy();
       },
     },


### PR DESCRIPTION
### Description
Fixes incorrect the "with an exceeds balance" test steps for incorrect-inputs spec.  

### Other changes

### Checklist before requesting a review
- [x] Performed a self-review of my own code
- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Tests passed locally
- [x] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues
-
