### PR TITLE
Fix: Changed regression cron to every work day instead of every day

### DIFF
--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -2,7 +2,7 @@ name: Regression Test Run
 
 on:
   schedule:
-    - cron: "0 4 * * *" # Every night at 4:00 AM UTC
+    - cron: "0 4 * * 1-5" # Monday to Friday at 4:00 AM UTC
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
### Description
Initially, the cron has been done to check it out at the nearest night - it's passed successfully, so it's time to correct it to the right cron: from Monday to Friday, only working days.

### Other changes

### Checklist before requesting a review

- [x] Performed a self-review of my own code
- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [x] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues
