### PR TITLE
Fix: Corrected regression report, mutual "upload artefacts" conditions, and input descriptions

### DIFF
--- a/.github/workflows/common-test.yml
+++ b/.github/workflows/common-test.yml
@@ -13,15 +13,15 @@ on:
         required: false
         type: string
       HTML_REPORT_GENERATION:
-        description: "Flag to configure html report generation"
+        description: "HTML report generation"
         required: true
         type: string
       TESTOMAT_REPORT_GENERATION:
-        description: "Flag to configure testomat test run report generation"
+        description: "Testomat test run report generation"
         required: true
         type: string
       TESTOMATIO_TITLE:
-        description: "Title of test run in the test management system"
+        description: "Title of test run in the Testomat"
         required: true
         type: string
     secrets:
@@ -29,7 +29,7 @@ on:
         description: "Seed phrase to connect wallet"
         required: true
       TESTOMAT_API_KEY:
-        description: "Testomat api key for defining test management system account"
+        description: "API key to sync with Testomat account"
         required: true
 
 jobs:
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ success() && inputs.HTML_REPORT_GENERATION == 'true' || success() && inputs.HTML_REPORT_GENERATION == 'onFailure' && failure() }}
+        if: ${{ (success() && inputs.HTML_REPORT_GENERATION == 'true') || (failure() && inputs.HTML_REPORT_GENERATION == 'onFailure') }}
         with:
           name: playwright-report
           path: artifacts/reports/playwright-report/

--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       HTML_REPORT_GENERATION:
         type: choice
-        description: "Configuration of HTML report generation"
+        description: "HTML report generation"
         default: "onFailure"
         options:
           - "true"
@@ -15,7 +15,7 @@ on:
           - "onFailure"
       TESTOMAT_REPORT_GENERATION:
         type: choice
-        description: "Configuration of Testomat test run report generation"
+        description: "Testomat test run report generation"
         default: "true"
         options:
           - "true"
@@ -27,8 +27,8 @@ jobs:
     uses: ./.github/workflows/common-test.yml
     with:
       SPECS_TYPE: ${{ 'all' }}
-      HTML_REPORT_GENERATION: ${{ inputs.HTML_REPORT_GENERATION }}
-      TESTOMAT_REPORT_GENERATION: ${{ inputs.TESTOMAT_REPORT_GENERATION }}
+      HTML_REPORT_GENERATION: ${{ contains(fromJSON('["true", "false", "onFailure"]'), inputs.HTML_REPORT_GENERATION) || 'onFailure' }}
+      TESTOMAT_REPORT_GENERATION: ${{ contains(fromJSON('["true", "false"]'), inputs.TESTOMAT_REPORT_GENERATION) || 'true' }}
       TESTOMATIO_TITLE: "Regression"
 
     secrets:

--- a/.github/workflows/specific-test.yml
+++ b/.github/workflows/specific-test.yml
@@ -16,7 +16,7 @@ on:
           - api
       HTML_REPORT_GENERATION:
         type: choice
-        description: "Configuration of HTML report generation"
+        description: "HTML report generation"
         default: "onFailure"
         options:
           - "true"
@@ -24,7 +24,7 @@ on:
           - "onFailure"
       TESTOMAT_REPORT_GENERATION:
         type: choice
-        description: "Configuration of Testomat test run report generation"
+        description: "Testomat test run report generation"
         default: "true"
         options:
           - "true"


### PR DESCRIPTION
### Description
Previously, I added Testomat test run report for regression run to automatically create test run reports - it hasn't created it automatically because of missing default values in the condition. Also, I noticed that upload artefacts test step has a bug - fixed here.

### Other changes
- Fixed the 'Upload artefacts' CI step to avoid incorrect result on failure
- Corrected the descriptions for test jobs

### Checklist before requesting a review

- [x] Performed a self-review of my own code
- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [x] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
