### PR TITLE
Fix: Increased CI and local test runner timeout to prevent flaky timeout test failures

### DIFF
--- a/src/constants/timeouts.constants.ts
+++ b/src/constants/timeouts.constants.ts
@@ -4,8 +4,8 @@ import { envHelper } from "@helpers/env/env.helper";
 export const timeouts = {
   get testRunner(): number {
     return envHelper.isCI()
-      ? 120_000
-      : Number(processEnv.TEST_RUNNER_TIMEOUT) || 90_000;
+      ? 200_000
+      : Number(processEnv.TEST_RUNNER_TIMEOUT) || 120_000;
   },
   get isOpenPage(): number {
     return this.m;


### PR DESCRIPTION
### Description

Sometimes, there are test failures due to test runner timeout on CI and local for a swap flow testing. It takes a lot of time to prepare txs - I increased timeout to prevent timeout test failures

### Other changes

### Checklist before requesting a review

- [x] Performed a self-review of my own code
- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] Tests passed locally
- [x] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
