### PR TITLE
Test: Added tests for swap-in and swap-out amount types

### DIFF
--- a/specs/web/swap/swap-by-amount-types.spec.ts
+++ b/specs/web/swap/swap-by-amount-types.spec.ts
@@ -1,0 +1,53 @@
+import { expect } from "@fixtures/common.fixture";
+import { Token } from "@constants/token.constants";
+import { suite } from "@helpers/suite/suite.helper";
+import { AmountType } from "@services/types/swap.service.types";
+
+suite({
+  name: "Swap - By amount type",
+  beforeAll: async ({ web, wallet }) => {
+    await web.main.openAppWithConnectedWallet(wallet);
+  },
+  afterEach: async ({ web }) => {
+    await web.swap.browser.refresh();
+  },
+  tests: [
+    {
+      name: "Swap-in",
+      testCaseId: "@Tab822de9",
+      disable: { reason: "Swap-in amount tests all time with all swap tests" },
+      test: async ({ web, wallet }) => {
+        await web.swap.fillForm({
+          tokens: { from: Token.CELO, to: Token.cREAL },
+          fromAmount: "0.0001",
+        });
+        expect
+          .soft(
+            Number(await web.swap.getAmountByType(AmountType.Out)),
+            "swap-out amount is not calculated",
+          )
+          .toBeGreaterThan(0);
+        await web.swap.start();
+        await wallet.helper.approveTransactionTwice();
+        await web.swap.confirm.expectSuccessfulTransaction();
+      },
+    },
+    {
+      name: "Swap-out",
+      testCaseId: "@T3c8db175",
+      test: async ({ web, wallet }) => {
+        await web.swap.fillForm({
+          tokens: { from: Token.cEUR, to: Token.CELO },
+          toAmount: "0.0001",
+        });
+        expect(
+          Number(await web.swap.getAmountByType(AmountType.In)),
+          "swap-in amount is not calculated",
+        ).toBeGreaterThan(0);
+        await web.swap.start();
+        await wallet.helper.approveTransactionTwice();
+        await web.swap.confirm.expectSuccessfulTransaction();
+      },
+    },
+  ],
+});

--- a/src/application/web/services/swap.service.ts
+++ b/src/application/web/services/swap.service.ts
@@ -4,6 +4,7 @@ import { waiterHelper } from "@helpers/waiter/waiter.helper";
 import { timeouts } from "@constants/timeouts.constants";
 import { loggerHelper } from "@helpers/logger/logger.helper";
 import {
+  AmountType,
   ISwapInputs,
   ISwapServiceArgs,
 } from "@services/types/swap.service.types";
@@ -26,6 +27,7 @@ export interface ISwapService {
   swapInputs: () => Promise<ISwapInputs>;
   getCurrentPriceFromSwap: (waitTimeout?: number) => Promise<string>;
   getCurrentToTokenName: () => Promise<string>;
+  getAmountByType: (amountType: AmountType) => Promise<string>;
   isAmountRequiredValidationThere: () => Promise<boolean>;
   isAmountExceedValidationThere: () => Promise<boolean>;
   isAmountTooSmallValidationThere: () => Promise<boolean>;
@@ -114,6 +116,14 @@ export class SwapService extends BaseService implements ISwapService {
       "To Token",
       "",
     );
+  }
+
+  async getAmountByType(amountType: AmountType): Promise<string> {
+    const amountInput =
+      amountType === AmountType.In
+        ? this.page.fromAmountInput
+        : this.page.toAmountInput;
+    return amountInput.getValue();
   }
 
   async useFullBalance(): Promise<void> {

--- a/src/application/web/services/types/swap.service.types.ts
+++ b/src/application/web/services/types/swap.service.types.ts
@@ -21,3 +21,8 @@ export interface ISwapInputs {
   beforeSwapPrice: string;
   afterSwapPrice: string;
 }
+
+export enum AmountType {
+  In = "In",
+  Out = "Out",
+}

--- a/src/helpers/suite/suite.helper.ts
+++ b/src/helpers/suite/suite.helper.ts
@@ -145,16 +145,15 @@ class Utils {
   }
 
   private addDisableAnnotations(disable: IDisable): void {
-    testFixture.info().annotations.push(
-      {
-        type: `Reason`,
-        description: disable?.reason,
-      },
-      disable?.link && {
+    testFixture.info().annotations.push({
+      type: "Reason",
+      description: disable.reason,
+    });
+    disable?.link &&
+      testFixture.info().annotations.push({
         type: "Link",
         description: disable?.link,
-      },
-    );
+      });
   }
 }
 


### PR DESCRIPTION
### Description
Added new tests for a swap-in and swap-out amount types. I've added for both, but we actually test a swap-in amount all the time in the scope of every swap flow tests - therefore, I've added for both but the swap-in one is disabled.

### Other changes
Fixed a disable issue for pushing an undefined annotation for disable link where there is no any of that.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes #23 
