### PR TITLE
Fix: Missing report default on CI

### DIFF
--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -29,9 +29,9 @@ jobs:
     with:
       SPECS_TYPE: web
       IS_PARALLEL_RUN: "true"
-      HTML_REPORT_GENERATION: ${{ inputs.HTML_REPORT_GENERATION }}
+      HTML_REPORT_GENERATION: ${{ inputs.HTML_REPORT_GENERATION || 'onFailure' }}
       HTML_REPORT_NAME: "web-parallel-regression"
-      TESTOMAT_REPORT_GENERATION: ${{ inputs.TESTOMAT_REPORT_GENERATION }}
+      TESTOMAT_REPORT_GENERATION: ${{ inputs.TESTOMAT_REPORT_GENERATION || 'true'  }}
       TESTOMATIO_TITLE: "Web Parallel-Regression"
 
     secrets:
@@ -46,9 +46,9 @@ jobs:
       SPECS_FOLDER_NAME: swap
       SPEC_NAMES: swapping
       IS_PARALLEL_RUN: "false"
-      HTML_REPORT_GENERATION: ${{ inputs.HTML_REPORT_GENERATION }}
+      HTML_REPORT_GENERATION: ${{ inputs.HTML_REPORT_GENERATION || 'onFailure' }}
       HTML_REPORT_NAME: "web-sequential-regression"
-      TESTOMAT_REPORT_GENERATION: ${{ inputs.TESTOMAT_REPORT_GENERATION }}
+      TESTOMAT_REPORT_GENERATION: ${{ inputs.TESTOMAT_REPORT_GENERATION || 'true' }}
       TESTOMATIO_TITLE: "Web Sequential-Regression"
 
     secrets:


### PR DESCRIPTION
### Description
Missing report default on CI for regression job

### Other changes
None

### Checklist before requesting a review

- [x] Performed a self-review of my own code
- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
