### PR TITLE
Fix: Updated metamask action usages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@tenkeylabs/dappwright": "2.9.0",
+        "@tenkeylabs/dappwright": "2.9.1",
         "dotenv": "16.3.1",
         "lodash": "4.17.21",
         "log4js": "6.9.1",
@@ -2138,9 +2138,9 @@
       }
     },
     "node_modules/@tenkeylabs/dappwright": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@tenkeylabs/dappwright/-/dappwright-2.9.0.tgz",
-      "integrity": "sha512-KDfcnGeNLrgDXZoI6LqD9Lb7GFKasig6Tz+tE8FmAVPKBOIHcnGvaIDLwmpy8U+9XkDdPUeOISObejKyR7p9EQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tenkeylabs/dappwright/-/dappwright-2.9.1.tgz",
+      "integrity": "sha512-MqMvm5oEXI+TmKr4qYd6goWJL+dNO6lU3Xe0BJIzl14hmhmH39k/Qe499/jScSbU37popfdbcBGmewk3qbnJug==",
       "dependencies": {
         "node-stream-zip": "^1.13.0"
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=18.20.0"
   },
   "dependencies": {
-    "@tenkeylabs/dappwright": "2.9.0",
+    "@tenkeylabs/dappwright": "2.9.1",
     "dotenv": "16.3.1",
     "lodash": "4.17.21",
     "log4js": "6.9.1",

--- a/specs/web/network/switch-network.spec.ts
+++ b/specs/web/network/switch-network.spec.ts
@@ -32,7 +32,7 @@ suite({
         await web.main.walletSettingsPopup.networkDetails.switchNetworkByName(
           Network.Baklava,
         );
-        await wallet.metamask.reject();
+        await wallet.helper.rejectNetworkSwitch();
         expect
           .soft(
             await web.main.page.failedSwitchNetworkNotificationLabel.isDisplayed(),

--- a/src/application/web/services/confirm-swap/confirm-swap.service.ts
+++ b/src/application/web/services/confirm-swap/confirm-swap.service.ts
@@ -40,24 +40,9 @@ export class ConfirmSwapService
   }
 
   async expectSuccessfulTransaction(): Promise<void> {
-    expect
-      .soft(
-        await this.isSwapPerformingPopupThere(),
-        "missing swap performing popup",
-      )
-      .toBeTruthy();
-    expect
-      .soft(
-        await this.isApproveCompleteNotificationThere(),
-        "missing approve complete notification",
-      )
-      .toBeTruthy();
-    expect
-      .soft(
-        await this.isSwapCompleteNotificationThere(),
-        "missing swap complete notification",
-      )
-      .toBeTruthy();
+    expect.soft(await this.isSwapPerformingPopupThere()).toBeTruthy();
+    expect.soft(await this.isApproveCompleteNotificationThere()).toBeTruthy();
+    expect.soft(await this.isSwapCompleteNotificationThere()).toBeTruthy();
   }
 
   async navigateToCeloExplorer(): Promise<void> {
@@ -74,8 +59,10 @@ export class ConfirmSwapService
 
   async isSwapCompleteNotificationThere(): Promise<boolean> {
     return this.page.swapCompleteNotificationLabel.waitUntilDisplayed(
-      timeouts.l,
-      { throwError: false },
+      timeouts.xl,
+      {
+        throwError: false,
+      },
     );
   }
 

--- a/src/application/web/services/confirm-swap/confirm-swap.service.ts
+++ b/src/application/web/services/confirm-swap/confirm-swap.service.ts
@@ -36,6 +36,9 @@ export class ConfirmSwapService
   }
 
   async finish(wallet: IWallet): Promise<void> {
+    // confirm approval tx
+    await wallet.helper.confirmTransaction();
+    // confirm swap tx
     await wallet.helper.confirmTransaction();
   }
 

--- a/src/application/web/services/confirm-swap/confirm-swap.service.ts
+++ b/src/application/web/services/confirm-swap/confirm-swap.service.ts
@@ -36,8 +36,7 @@ export class ConfirmSwapService
   }
 
   async finish(wallet: IWallet): Promise<void> {
-    await wallet.helper.approveTransactionTwice();
-    await wallet.metamask.confirmTransaction();
+    await wallet.helper.confirmTransaction();
   }
 
   async expectSuccessfulTransaction(): Promise<void> {


### PR DESCRIPTION
### Description
Metamask was updated their UI interface. So, flows was changed by buttons, that's why it's been updated on the our side to execute the approving tx and switch network

### Other changes
None

### Checklist before requesting a review

- [x] Performed a self-review of my own code
- [x] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes #46 
