### PR TITLE
Fix: Confirm txs for swap tests

### DIFF
--- a/specs/web/amount-validations/swap-in-amount.spec.ts
+++ b/specs/web/amount-validations/swap-in-amount.spec.ts
@@ -6,7 +6,7 @@ suite({
   name: "Amount Validations - Swap-In Amount",
   beforeEach: async ({ web }) => {
     await web.main.connectWalletByName(WalletName.Metamask);
-    await web.main.waitForBalanceToLoad();
+    await web.main.waitForBalanceToLoad({ shouldOpenSettings: true });
   },
   tests: [
     {

--- a/specs/web/swap/swapping-by-amount-types.spec.ts
+++ b/specs/web/swap/swapping-by-amount-types.spec.ts
@@ -32,8 +32,7 @@ suite({
           .soft(Number(await web.swap.getAmountByType(AmountType.Out)))
           .toBeGreaterThan(0);
         await web.swap.start();
-        await web.swap.confirm.finish();
-        await web.swap.confirm.expectSuccessfulNotifications();
+        await web.swap.confirm.process();
         await web.main.expectIncreasedBalance({
           initialBalance,
           tokenName: Token.CELO,
@@ -53,8 +52,7 @@ suite({
           .soft(Number(await web.swap.getAmountByType(AmountType.In)))
           .toBeGreaterThan(0);
         await web.swap.start();
-        await web.swap.confirm.finish();
-        await web.swap.confirm.expectSuccessfulNotifications();
+        await web.swap.confirm.process();
         await web.main.expectIncreasedBalance({
           initialBalance,
           tokenName: Token.CELO,

--- a/specs/web/swap/swapping-by-token-pairs.spec.ts
+++ b/specs/web/swap/swapping-by-token-pairs.spec.ts
@@ -100,8 +100,7 @@ suite({
             fromAmount: testCase?.fromAmount || defaultSwapAmount,
           });
           await web.swap.start();
-          await web.swap.confirm.finish();
-          await web.swap.confirm.expectSuccessfulNotifications();
+          await web.swap.confirm.process();
           await web.main.expectIncreasedBalance({
             initialBalance,
             tokenName: testCase.toToken,

--- a/specs/web/swap/swapping-with-custom-slippage.spec.ts
+++ b/specs/web/swap/swapping-with-custom-slippage.spec.ts
@@ -52,8 +52,7 @@ suite({
           });
           expect.soft(await web.swap.isCurrentPriceThere()).toBeTruthy();
           await web.swap.start();
-          await web.swap.confirm.finish();
-          await web.swap.confirm.expectSuccessfulNotifications();
+          await web.swap.confirm.process();
           await web.main.expectIncreasedBalance({
             tokenName: toToken,
             initialBalance,

--- a/src/application/web/services/confirm-swap/confirm-swap.service.types.ts
+++ b/src/application/web/services/confirm-swap/confirm-swap.service.types.ts
@@ -6,8 +6,7 @@ import { IMetamaskHelper } from "@helpers/wallet/metamask-wallet.helper";
 export interface IConfirmSwapService {
   getCurrentPriceFromConfirmation: () => Promise<string>;
   getCurrentPriceFromSwap: (waitTimeout?: number) => Promise<string>;
-  finish: (metamaskHelper: IMetamaskHelper) => Promise<void>;
-  expectSuccessfulNotifications: () => Promise<void>;
+  process: (metamaskHelper: IMetamaskHelper) => Promise<void>;
   navigateToCeloExplorer: () => Promise<void>;
   isSwapPerformingPopupThere: () => Promise<boolean>;
   isApproveCompleteNotificationThere: () => Promise<boolean>;

--- a/src/application/web/services/swap/swap.service.ts
+++ b/src/application/web/services/swap/swap.service.ts
@@ -36,7 +36,7 @@ export class SwapService extends BaseService implements ISwapService {
     await this.page.continueButton.click();
     await this.confirm.page.verifyIsOpen();
     await waiterHelper.sleep(timeouts.xs, {
-      sleepReason: "Doesn't open metamask tx because fast clicking on button",
+      sleepReason: "https://linear.app/mento-labs/issue/SUP-160",
     });
     await waiterHelper.retry(
       async () => {
@@ -74,10 +74,6 @@ export class SwapService extends BaseService implements ISwapService {
     await this.selectTokens(tokens);
     fromAmount && (await this.page.fromAmountInput.enterText(fromAmount));
     toAmount && (await this.page.toAmountInput.enterText(toAmount));
-    await waiterHelper.sleep(timeouts.s, {
-      sleepReason:
-        "flaky incorrect continueButton state by fast pressing after entering amount",
-    });
   }
 
   async continueToConfirmation(): Promise<void> {

--- a/src/application/web/services/swap/swap.service.ts
+++ b/src/application/web/services/swap/swap.service.ts
@@ -190,7 +190,7 @@ export class SwapService extends BaseService implements ISwapService {
           async () => {
             return this.browser.hasConsoleErrorsMatchingText("no valid median");
           },
-          5,
+          8,
           {
             interval: timeouts.xs,
             throwError: false,

--- a/src/constants/timeouts.constants.ts
+++ b/src/constants/timeouts.constants.ts
@@ -1,11 +1,11 @@
 import { processEnv } from "@helpers/processEnv/processEnv.helper";
 import { envHelper } from "@helpers/env/env.helper";
 
+const { TEST_RUNNER_TIMEOUT } = processEnv;
+
 export const timeouts = {
   get testRunner(): number {
-    return envHelper.isCI()
-      ? 200_000
-      : Number(processEnv.TEST_RUNNER_TIMEOUT) || 120_000;
+    return Number(processEnv.TEST_RUNNER_TIMEOUT) ?? 200_000;
   },
   get isOpenPage(): number {
     return this.m;

--- a/src/helpers/wallet/metamask-wallet.helper.ts
+++ b/src/helpers/wallet/metamask-wallet.helper.ts
@@ -76,19 +76,4 @@ export class MetamaskHelper implements IMetamaskHelper {
     await this.confirmTransaction();
     await this.rejectTransaction();
   }
-
-  // todo: Think about
-  // private async callMetamaskMethod<T>(
-  //   method: (...args) => Promise<T>,
-  //   args?: unknown[],
-  // ) {
-  //   try {
-  //     console.log({ method, args });
-  //     return method(args);
-  //   } catch (error) {
-  //     throw new Error(
-  //       `Metamask '${method.name}' method has failed: ${error.message}`,
-  //     );
-  //   }
-  // }
 }

--- a/src/helpers/wallet/metamask-wallet.helper.ts
+++ b/src/helpers/wallet/metamask-wallet.helper.ts
@@ -1,6 +1,8 @@
 import { MetaMask } from "@synthetixio/synpress/playwright";
 
 import { ClassLog } from "@decorators/logger.decorators";
+import { timeouts } from "@constants/timeouts.constants";
+import { waiterHelper } from "@helpers/waiter/waiter.helper";
 
 export interface IMetamaskHelper {
   rawModule: MetaMask;
@@ -54,7 +56,16 @@ export class MetamaskHelper implements IMetamaskHelper {
   }
 
   async confirmTransaction(): Promise<void> {
-    this.metamask.confirmTransaction();
+    await waiterHelper.retry(
+      async () => {
+        await this.metamask.confirmTransaction();
+      },
+      5,
+      {
+        resolveWhenNoException: true,
+        errorMessage: "couldn't confirm transaction",
+      },
+    );
   }
 
   async rejectTransaction(): Promise<void> {


### PR DESCRIPTION
### Description

After migrating to the Synpress library, we encountered several flaky failures during the regression run while confirming transactions with the swapping flow. This fix prevents an error from being thrown when the MetaMask popup is not clickable on the Synpress library side; instead, we retry multiple times to confirm the transaction.

### Other changes
* Decreased test execution time by adding smart wait for a current price that prevents several unused retries to check the 'no valid median' case.
* Removed unused static waits.
* Added a correct sleep reason (reason for static wait), and added but for this reason.
* Added flag to open settings in the 'beforeEach' hook for the 'swap-in-amount' spec

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
