### PR TITLE
Fix: 'Prices are equal on all stages and correct' test

### DIFF
--- a/specs/web/swap/prices.spec.ts
+++ b/specs/web/swap/prices.spec.ts
@@ -14,7 +14,7 @@ suite({
       testCaseId: "@T2332ee03",
       test: async ({ web }) => {
         await web.swap.fillForm({
-          tokens: { from: Token.cEUR, to: Token.CELO },
+          tokens: { from: Token.cUSD, to: Token.CELO },
           fromAmount: "0.0001",
         });
         expect(await web.swap.isCurrentPriceThere()).toBeTruthy();

--- a/src/application/web/services/swap/swap.service.ts
+++ b/src/application/web/services/swap/swap.service.ts
@@ -33,7 +33,6 @@ export class SwapService extends BaseService implements ISwapService {
   async start(): Promise<void> {
     await this.verifyNoValidMedianCase();
     await this.continueToConfirmation();
-    await this.confirm.page.verifyIsOpen();
     await waiterHelper.retry(
       async () => {
         await this.confirm.page.swapButton.waitUntilEnabled(timeouts.s);
@@ -75,12 +74,14 @@ export class SwapService extends BaseService implements ISwapService {
   }
 
   async continueToConfirmation(): Promise<void> {
-    return this.page.continueButton.click();
+    await this.page.continueButton.click();
+    await this.confirm.page.verifyIsOpen();
   }
 
   async swapInputs(): Promise<ISwapInputs> {
     const beforeSwapPrice = await this.getCurrentPriceFromSwap();
     await this.page.swapInputsButton.click();
+    await this.waitForLoadedCurrentPrice();
     const afterSwapPrice = await this.getCurrentPriceFromSwap(timeouts.xxs);
     return { beforeSwapPrice, afterSwapPrice };
   }


### PR DESCRIPTION
### Description
The 'Prices are equal on all stages, and correct' test failed on today's regression because of the new default wait for element and throw error handling - the handling works fine, just updated conditions for test to wait for confirmation state and after take a current price.

### Other changes
None

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
