### PR TITLE
Refactor: Updated useful logs, CI param, envHelper methods, README, and def .env constants

### DIFF
--- a/.github/workflows/specific-test.yml
+++ b/.github/workflows/specific-test.yml
@@ -44,9 +44,12 @@ on:
         required: false
         type: string
       IS_MAINNET:
+        type: choice
         description: "Mainnet test run flag"
-        required: false
-        type: string
+        default: "false"
+        options:
+          - "true"
+          - "false"
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@
 
 ## Pre-conditions
 
-1. Execute `npm install`
-2. Paste a seed phrase into the `SEED_PHRASE` variable (can be taken from [CI](https://github.com/mento-protocol/mento-automation-tests/settings/secrets/actions))
+1. Execute `npm install`.
+2. Paste a seed phrase into the `SEED_PHRASE` and a `WALLET_PASSWORD` variables.
+3. Execute `npm run build-synpress-cache`.
 
 ## Environment Variables
 
-#### .env file creates automatically as a "postinstall" on `npm install` command execution
+#### .env file creates automatically via "postinstall" on `npm install` command execution
 
 | Variable                   | Example           | Description                                                                                                                  |
 | -------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------- |

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:staged": "eslint '*.ts' --fix",
     "lint": "eslint 'src/**/*.{js,ts}'",
     "codeCheck": "tsc && npm run linter",
+    "build-synpress-cache": "npx synpress src/wallet-setups --force",
     "prepare": "husky install",
     "postinstall": "tsx src/tools/env.tool.ts"
   },

--- a/src/constants/default-env-variables.constants.ts
+++ b/src/constants/default-env-variables.constants.ts
@@ -1,26 +1,21 @@
 export const defaultEnvVariables = `ENV=prod
-
-SEED_PHRASE=
+SEED_PHRASE="affair pattern detail feature plunge cruise spot deal strike mango cherry combine"
+WALLET_PASSWORD="kovowevynklsac28mv80ncwoe12"
 
 SPECS_TYPE=web
-
-#SPECS_FOLDER_NAME=wallet
-
+#SPECS_FOLDER_NAME=amount-validations
 SPEC_NAMES=
-#wallet
-#incorrect-inputs
-#slippage
-#price
+#swapping-by-amount-types
+#connect-wallet
 
-IS_PARALLEL=false
+LOG_LEVEL=ALL
+#TEST_RETRY=1
+#IS_MAINNET=true
+#TEST_RUNNER_TIMEOUT=
+#IS_PARALLEL_RUN=true
+#CUSTOM_URL=
 
-#TEST_RUN_TIMEOUT=
-#TEST_TIMEOUT=
-#LOG_LEVEL=ALL
-#TEST_RETRY=0
-#IS_MAINNET=false
+#TESTOMAT_REPORT_GENERATION=true
+#TESTOMAT_API_KEY=
 
-#TESTOMAT_REPORT_GENERATION=false
-#TESTOMATIO_TITLE=yourOwnTitle
-TESTOMAT_API_KEY=
 `;

--- a/src/helpers/env/env.helper.ts
+++ b/src/helpers/env/env.helper.ts
@@ -1,11 +1,9 @@
 import { processEnv } from "@helpers/processEnv/processEnv.helper";
 import { magicStrings } from "@constants/magic-strings.constants";
 import { primitiveHelper } from "@helpers/primitive/primitive.helper";
-import { loggerHelper } from "@helpers/logger/logger.helper";
 
-const { ENV, CI, CUSTOM_URL, IS_MAINNET } = processEnv;
-
-const logger = loggerHelper.get("Env-Helper");
+const { ENV, CI, CUSTOM_URL, IS_MAINNET, SEED_PHRASE, WALLET_PASSWORD } =
+  processEnv;
 
 export class EnvHelper {
   getEnv(): string {
@@ -13,8 +11,7 @@ export class EnvHelper {
   }
 
   getBaseWebUrl(): string {
-    if (CUSTOM_URL) {
-      logger.debug(`❕ Running tests with custom URL: ${CUSTOM_URL}`);
+    if (this.isCustomUrl()) {
       return CUSTOM_URL;
     }
     return magicStrings.url.web[this.getEnv()].base;
@@ -25,8 +22,13 @@ export class EnvHelper {
   }
 
   getSeedPhrase(): string {
-    if (!processEnv.SEED_PHRASE) throw new Error("Seed phrase isn't provided");
-    return processEnv.SEED_PHRASE;
+    if (!SEED_PHRASE) throw new Error("Seed phrase isn't provided");
+    return SEED_PHRASE;
+  }
+
+  getWalletPassword(): string {
+    if (!WALLET_PASSWORD) throw new Error("Wallet password isn't provided");
+    return WALLET_PASSWORD;
   }
 
   isCI(): boolean {
@@ -35,6 +37,10 @@ export class EnvHelper {
 
   isMainnet(): boolean {
     return primitiveHelper.string.toBoolean(IS_MAINNET);
+  }
+
+  isCustomUrl(): boolean {
+    return Boolean(CUSTOM_URL?.length);
   }
 }
 

--- a/src/helpers/suite/suite.helper.ts
+++ b/src/helpers/suite/suite.helper.ts
@@ -14,14 +14,11 @@ export function suite({
   afterEach,
   afterAll,
 }: ISuiteArgs): void {
-  logger.info(
-    `Running '${suiteName}' suite against '${envHelper.getEnv()}' on ${
-      process.pid
-    } PID`,
-  );
-
   testFixture.describe(suiteName, () => {
-    beforeAll && testFixture.beforeAll(async ({ api }) => beforeAll({ api }));
+    testFixture.beforeAll(async ({ api }) => {
+      logRunDetails(suiteName);
+      beforeAll && (await beforeAll({ api }));
+    });
     afterAll && testFixture.afterAll(async ({ api }) => afterAll({ api }));
 
     beforeEach &&
@@ -99,3 +96,14 @@ export const testUtils = {
     };
   },
 };
+
+function logRunDetails(suiteName: string): void {
+  const env = envHelper.isCustomUrl()
+    ? `Custom with '${envHelper.getBaseWebUrl()}' URL`
+    : `Regular '${envHelper.getEnv()}' with '${envHelper.getBaseWebUrl()}' URL`;
+  const chain = envHelper.isMainnet()
+    ? `'Celo' mainnet`
+    : `'Alfajores' testnet`;
+  const config = `\n        ENV: ${env}\n        CHAIN: ${chain}\n        PID: ${process.pid}`;
+  logger.info(`Running '${suiteName}' suite with configuration: ${config}`);
+}

--- a/src/wallet-setups/basic.setup.ts
+++ b/src/wallet-setups/basic.setup.ts
@@ -1,16 +1,14 @@
 import { defineWalletSetup } from "@synthetixio/synpress";
 import { MetaMask } from "@synthetixio/synpress/playwright";
 
-import { processEnv } from "@helpers/processEnv/processEnv.helper";
+import { envHelper } from "@helpers/env/env.helper";
+
+const walletPassword = envHelper.getWalletPassword();
 
 export default defineWalletSetup(
-  processEnv.WALLET_PASSWORD,
+  walletPassword,
   async (context, walletPage) => {
-    const metamask = new MetaMask(
-      context,
-      walletPage,
-      processEnv.WALLET_PASSWORD,
-    );
-    await metamask.importWallet(processEnv.SEED_PHRASE);
+    const metamask = new MetaMask(context, walletPage, walletPassword);
+    await metamask.importWallet(envHelper.getSeedPhrase());
   },
 );


### PR DESCRIPTION
### Description

1. After the migration to Synpress, some new vars for .env were added, so the file had to be updated with the def .env constants and README.
2. Updated the run suite log to make it more straightforward for runners (added a detailed configuration list).
3. Change CI Mainnet param to dropdown instead of input.
4. Corrected envHelper methods to get a seed and a wallet password (replaced usages).
5. Added command to build the synpress cache with deleting the existing ones (for local usage). 

### Other changes
None

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
