### PR TITLE
Fix: Changed to run parallel tests via mainnet and one specified token for prices test

### DIFF
--- a/.github/workflows/web-regression-test.yml
+++ b/.github/workflows/web-regression-test.yml
@@ -53,6 +53,7 @@ jobs:
     with:
       SPECS_TYPE: web
       IS_PARALLEL_RUN: "true"
+      IS_MAINNET: "true"
       HTML_REPORT_GENERATION: ${{ inputs.HTML_REPORT_GENERATION || 'onFailure' }}
       HTML_REPORT_NAME: "mento-web-parallel-regression"
       TESTOMAT_REPORT_GENERATION: ${{ inputs.TESTOMAT_REPORT_GENERATION || 'true'  }}

--- a/specs/web/swap/prices.spec.ts
+++ b/specs/web/swap/prices.spec.ts
@@ -53,7 +53,7 @@ suite({
       testCaseId: "@T80d4fbc3",
       test: async ({ web }) => {
         await web.swap.fillForm({
-          tokens: { from: Token.cCOP },
+          tokens: { from: Token.cUSD },
         });
         await web.swap.useFullBalance();
         expect(await web.swap.isConsiderKeepNotificationThere()).toBeFalsy();


### PR DESCRIPTION
### Description

Parallel and sequential modes separate the regression. The parallel part of it doesn't interact with swap on an ongoing base, so I moved it to mainnet to avoid additional actions.

### Other changes
Changed a specified token for price test to be aligned with available tokens on mainnet

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
