### PR TITLE
Feat: Replaced to npm install for CI jobs

### DIFF
--- a/.github/workflows/common-test.yml
+++ b/.github/workflows/common-test.yml
@@ -88,7 +88,7 @@ jobs:
           node-version: 18.20.0
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Verify env config
         run: npm run verify-env-config


### PR DESCRIPTION
### Description

The `npm ci` doesn't for smoke run of mento-web so I moved to the `npm install`

### Other changes

_Describe any minor or "drive-by" changes here._

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
