### PR TITLE
Fix: Increased waitForBalance timeout, set longer timeouts to select tokens, and made up interfaces

### DIFF
--- a/src/application/web/page-elements/base/base.pe.ts
+++ b/src/application/web/page-elements/base/base.pe.ts
@@ -7,6 +7,8 @@ import {
   IBasePe,
   IClickParams,
   IGetTextParams,
+  IGetValueParams,
+  IHoverParams,
   IWaitUntilDisplayed,
 } from "@page-elements/index";
 import { waiterHelper } from "@helpers/waiter/waiter.helper";
@@ -30,11 +32,11 @@ export abstract class BasePe implements IBasePe {
   }
 
   async isEnabled({
-    timeout,
+    timeout = timeouts.action,
     throwError = true,
   }: IGetTextParams = {}): Promise<boolean> {
     try {
-      await this.waitUntilDisplayed(timeouts.action, { throwError });
+      await this.waitUntilDisplayed(timeout, { throwError });
       return (await this.element).isEnabled({ timeout });
     } catch (error) {
       const errorMessage = `Can't get text on element with '${this.locator}' locator.\nError details: ${error.message}`;
@@ -44,11 +46,11 @@ export abstract class BasePe implements IBasePe {
   }
 
   async click({
+    timeout = timeouts.action,
     throwError = true,
-    timeout,
   }: IClickParams = {}): Promise<void> {
     const element = await this.element;
-    await this.waitUntilDisplayed(timeouts.action, { throwError });
+    await this.waitUntilDisplayed(timeout, { throwError });
     try {
       if (await this.isEnabled()) {
         await element.click({ timeout });
@@ -70,11 +72,11 @@ export abstract class BasePe implements IBasePe {
   }
 
   async getText({
-    timeout,
+    timeout = timeouts.action,
     throwError = true,
   }: IGetTextParams = {}): Promise<string> {
     try {
-      await this.waitUntilDisplayed(timeouts.action, { throwError });
+      await this.waitUntilDisplayed(timeout, { throwError });
       return (await this.element).textContent({ timeout });
     } catch (error) {
       const errorMessage = `Can't get text on element with '${this.locator}' locator.\nError details: ${error.message}`;
@@ -83,15 +85,26 @@ export abstract class BasePe implements IBasePe {
     }
   }
 
-  async getValue({ throwError = true }: IGetValueParams = {}): Promise<string> {
+  async getValue({
+    timeout = timeouts.action,
+    throwError = true,
+  }: IGetValueParams = {}): Promise<string> {
     try {
-      await this.waitUntilDisplayed(timeouts.action, { throwError });
+      await this.waitUntilDisplayed(timeout, { throwError });
       return (await this.element).inputValue();
     } catch (error) {
       const errorMessage = `Can't get value on element with '${this.locator}' locator.\nError details: ${error.message}`;
       logger.error(errorMessage);
       if (throwError) throw new Error(errorMessage);
     }
+  }
+
+  async hover({
+    throwError = true,
+    timeout,
+  }: IHoverParams = {}): Promise<void> {
+    await this.waitUntilDisplayed(timeout, { throwError });
+    await (await this.element).hover();
   }
 
   async waitUntilDisplayed(
@@ -168,16 +181,4 @@ export abstract class BasePe implements IBasePe {
       return false;
     }
   }
-
-  async hover({
-    throwError = true,
-  }: { throwError?: boolean } = {}): Promise<void> {
-    await this.waitUntilDisplayed(timeouts.action, { throwError });
-    await (await this.element).hover();
-  }
-}
-
-interface IGetValueParams {
-  throwError?: boolean;
-  timeout?: number;
 }

--- a/src/application/web/page-elements/base/base.pe.types.ts
+++ b/src/application/web/page-elements/base/base.pe.types.ts
@@ -24,3 +24,7 @@ export interface IGetTextParams {
   timeout?: number;
   throwError?: boolean;
 }
+
+export interface IGetValueParams extends IGetTextParams {}
+
+export interface IHoverParams extends IGetTextParams {}

--- a/src/application/web/page-elements/dropdown/dropdown.ts
+++ b/src/application/web/page-elements/dropdown/dropdown.ts
@@ -1,5 +1,10 @@
 import { loggerHelper } from "@helpers/logger/logger.helper";
-import { BasePe, IDropdown, IDropdownArgs } from "@page-elements/index";
+import {
+  BasePe,
+  IDropdown,
+  IDropdownArgs,
+  ISelectOptionByNameParams,
+} from "@page-elements/index";
 
 const logger = loggerHelper.get("DropdownPe");
 
@@ -33,8 +38,11 @@ export class Dropdown<Options> extends BasePe implements IDropdown {
     }
   }
 
-  async selectOptionByName(name: string): Promise<void> {
+  async selectOptionByName(
+    name: string,
+    { timeout, throwError }: ISelectOptionByNameParams = {},
+  ): Promise<void> {
     await super.click();
-    return this.options[name].click();
+    return this.options[name].click({ timeout, throwError });
   }
 }

--- a/src/application/web/page-elements/dropdown/dropdown.types.ts
+++ b/src/application/web/page-elements/dropdown/dropdown.types.ts
@@ -1,8 +1,12 @@
 import { ElementSearcher } from "@helpers/element-finder/types/index.types";
+import { IGetTextParams } from "@page-elements/base/base.pe.types";
 
 export interface IDropdown {
   selectOptionByIndex: (index: number) => Promise<void>;
-  selectOptionByName: (name: string) => Promise<void>;
+  selectOptionByName: (
+    name: string,
+    params: ISelectOptionByNameParams,
+  ) => Promise<void>;
   selectFirstOption: () => Promise<void>;
   selectFirstExistingOption: () => Promise<void>;
 }
@@ -11,3 +15,5 @@ export interface IDropdownArgs<Options> {
   dropdownButton: ElementSearcher;
   options: Options;
 }
+
+export interface ISelectOptionByNameParams extends IGetTextParams {}

--- a/src/application/web/services/main/main.service.ts
+++ b/src/application/web/services/main/main.service.ts
@@ -147,7 +147,7 @@ export class MainService extends BaseService implements IMainService {
         result && logger.info("Balance is loaded successfully!");
         return result;
       },
-      timeouts.l,
+      timeouts.xxl,
       {
         throwError,
         interval: timeouts.xxs,

--- a/src/application/web/services/swap/swap.service.ts
+++ b/src/application/web/services/swap/swap.service.ts
@@ -49,8 +49,13 @@ export class SwapService extends BaseService implements ISwapService {
 
   async selectTokens(args: ISelectTokensArgs): Promise<void> {
     args?.from &&
-      (await this.page.fromTokenDropdown.selectOptionByName(args?.from));
-    args?.to && (await this.page.toTokenDropdown.selectOptionByName(args?.to));
+      (await this.page.fromTokenDropdown.selectOptionByName(args?.from, {
+        timeout: timeouts.xxs,
+      }));
+    args?.to &&
+      (await this.page.toTokenDropdown.selectOptionByName(args?.to, {
+        timeout: timeouts.xxs,
+      }));
   }
 
   async chooseSlippage(slippage: Slippage): Promise<void> {


### PR DESCRIPTION
### Description

The last regression was failed because of the 'can't get balance' reason. It just couldn't wait until it's loaded because this time that was a bit longer than usual. Also, it couldn't select the correct token because of selection was too fast and token list haven't refreshed.
Therefore, I increased the timeout for waiting for balance to be loaded, and token selection. Additionally, I cleaned interfaces for element's methods and set a default timeout properly.

### Other changes
* Cleaned interfaces
* Set a default timeout for element's method properly

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
