### PR TITLE
Feat: Updated ci secrets usages

### DIFF
--- a/.github/workflows/common-test.yml
+++ b/.github/workflows/common-test.yml
@@ -49,10 +49,10 @@ on:
         required: false
         type: string
     secrets:
-      SEED_PHRASE:
+      E2E_TEST_SEED_PHRASE:
         description: "Seed phrase to import wallet"
         required: true
-      WALLET_PASSWORD:
+      E2E_TEST_WALLET_PASSWORD:
         description: "Wallet password to login to wallet"
         required: true
       TESTOMAT_API_KEY:
@@ -71,8 +71,8 @@ jobs:
       IS_MAINNET: ${{ inputs.IS_MAINNET }}
       HTML_REPORT_GENERATION: ${{ inputs.HTML_REPORT_GENERATION }}
       TESTOMAT_REPORT_GENERATION: ${{ inputs.TESTOMAT_REPORT_GENERATION }}
-      SEED_PHRASE: ${{ secrets.SEED_PHRASE }}
-      WALLET_PASSWORD: ${{ secrets.WALLET_PASSWORD }}
+      SEED_PHRASE: ${{ secrets.E2E_TEST_SEED_PHRASE }}
+      WALLET_PASSWORD: ${{ secrets.E2E_TEST_WALLET_PASSWORD }}
       TESTOMAT_API_KEY: ${{ secrets.TESTOMAT_API_KEY }}
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,7 +17,4 @@ jobs:
       HTML_REPORT_NAME: "healthcheck-test-run"
       HTML_REPORT_GENERATION: "true"
       TESTOMAT_REPORT_GENERATION: "false"
-    secrets:
-      SEED_PHRASE: ${{ secrets.SEED_PHRASE }}
-      WALLET_PASSWORD: ${{ secrets.WALLET_PASSWORD }}
-      TESTOMAT_API_KEY: ${{ secrets.TESTOMAT_API_KEY }}
+    secrets: inherit

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,7 +14,6 @@ jobs:
       SPEC_NAMES: "connect-wallet"
       SPECS_TYPE: "web"
       IS_MAINNET: "true"
-      HTML_REPORT_NAME: "healthcheck-test-run"
-      HTML_REPORT_GENERATION: "true"
+      HTML_REPORT_NAME: "pr-check-run"
       TESTOMAT_REPORT_GENERATION: "false"
     secrets: inherit

--- a/.github/workflows/smoke-mento-web-test.yml
+++ b/.github/workflows/smoke-mento-web-test.yml
@@ -18,9 +18,9 @@ on:
         required: false
         default: "[Mento-Web] Smoke"
     secrets:
-      SEED_PHRASE:
+      E2E_TEST_SEED_PHRASE:
         required: true
-      WALLET_PASSWORD:
+      E2E_TEST_WALLET_PASSWORD:
         required: true
       TESTOMAT_API_KEY:
         required: true

--- a/.github/workflows/smoke-mento-web-test.yml
+++ b/.github/workflows/smoke-mento-web-test.yml
@@ -37,8 +37,8 @@ jobs:
       HTML_REPORT_NAME: "smoke-mento-web"
       HTML_REPORT_GENERATION: "onFailure"
       TESTOMAT_REPORT_GENERATION: "true"
-      SEED_PHRASE: ${{ secrets.SEED_PHRASE }}
-      WALLET_PASSWORD: ${{ secrets.WALLET_PASSWORD }}
+      SEED_PHRASE: ${{ secrets.E2E_TEST_SEED_PHRASE }}
+      WALLET_PASSWORD: ${{ secrets.E2E_TEST_WALLET_PASSWORD }}
       TESTOMAT_API_KEY: ${{ secrets.TESTOMAT_API_KEY }}
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/specific-test.yml
+++ b/.github/workflows/specific-test.yml
@@ -66,7 +66,4 @@ jobs:
       IS_PARALLEL_RUN: ${{ inputs.IS_PARALLEL_RUN }}
       CUSTOM_URL: ${{ inputs.CUSTOM_URL }}
       IS_MAINNET: ${{ inputs.IS_MAINNET }}
-    secrets:
-      SEED_PHRASE: ${{ secrets.SEED_PHRASE }}
-      WALLET_PASSWORD: ${{ secrets.WALLET_PASSWORD }}
-      TESTOMAT_API_KEY: ${{ secrets.TESTOMAT_API_KEY }}
+    secrets: inherit


### PR DESCRIPTION
### Description

We added the secrets on the org level - now it can be used from there.

### Other changes

None

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
