### PR TITLE
fix: swap with tx rejection test

### DIFF
--- a/specs/web/swap/swapping-with-tx-rejection.p2.spec.ts
+++ b/specs/web/swap/swapping-with-tx-rejection.p2.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from "@fixtures/common/common.fixture";
 import { defaultSwapAmount, Token } from "@constants/token.constants";
 import { suite } from "@helpers/suite/suite.helper";
-import { retryDataHelper } from "@helpers/retry-data/retry-data.helper";
 
 suite({
   name: "Swap - Transaction rejection",
@@ -10,31 +9,22 @@ suite({
   },
   tests: [
     {
-      name: "Reject approval transaction",
+      name: "Reject approval tx",
       testCaseId: "@Td5aa1954",
       test: async ({ web }) => {
         await web.swap.fillForm({
-          tokens: {
-            from: Token.CELO,
-            to: retryDataHelper.getRandomToken(Token.CELO, [
-              Token.cEUR,
-              Token.cUSD,
-              Token.cREAL,
-              Token.PUSO,
-              Token.cKES,
-            ]),
-          },
+          tokens: { from: Token.CELO, to: Token.cKES },
           fromAmount: defaultSwapAmount,
         });
         await web.swap.start();
         await web.swap.confirm.rejectByType("approval");
         expect(
-          await web.swap.confirm.isRejectApprovalTransactionNotificationThere(),
+          await web.swap.confirm.isRejectApprovalTxNotificationThere(),
         ).toBeTruthy();
       },
     },
     {
-      name: "Reject swap transaction",
+      name: "Reject swap tx",
       testCaseId: "@T09fd373a",
       test: async ({ web }) => {
         await web.swap.fillForm({
@@ -44,7 +34,7 @@ suite({
         await web.swap.start();
         await web.swap.confirm.rejectByType("swap");
         expect(
-          await web.swap.confirm.isRejectSwapTransactionNotificationThere(),
+          await web.swap.confirm.isRejectSwapTxNotificationThere(),
         ).toBeTruthy();
       },
     },

--- a/src/application/web/services/confirm-swap/confirm-swap.service.ts
+++ b/src/application/web/services/confirm-swap/confirm-swap.service.ts
@@ -70,16 +70,12 @@ export class ConfirmSwapService
     await this.metamaskHelper.confirmTransaction();
   }
 
-  async rejectByType(txTypeToReject: string): Promise<void> {
+  async rejectByType(txType: "approval" | "swap"): Promise<void> {
+    const isApprovalTx = txType === "approval";
     logger.warn(
-      `Rejection of ${
-        txTypeToReject === "approval" ? "approval and swap txs" : "swap tx"
-      }`,
+      `Rejection of ${isApprovalTx ? "approval and swap txs" : "swap tx"}`,
     );
-    txTypeToReject === "approval"
-      ? await this.rejectApprovalTx()
-      : await this.rejectSwapTx();
-
+    isApprovalTx ? await this.rejectApprovalTx() : await this.rejectSwapTx();
     await this.page.swapPerformingPopupLabel.waitUntilDisappeared(timeouts.s, {
       errorMessage: "Swap performing popup is still there",
     });
@@ -131,14 +127,14 @@ export class ConfirmSwapService
     );
   }
 
-  async isRejectApprovalTransactionNotificationThere(): Promise<boolean> {
+  async isRejectApprovalTxNotificationThere(): Promise<boolean> {
     return this.page.rejectApprovalTransactionNotificationLabel.waitUntilDisplayed(
       timeouts.s,
       { throwError: false },
     );
   }
 
-  async isRejectSwapTransactionNotificationThere(): Promise<boolean> {
+  async isRejectSwapTxNotificationThere(): Promise<boolean> {
     return this.page.rejectSwapTransactionNotificationLabel.waitUntilDisplayed(
       timeouts.s,
       { throwError: false },

--- a/src/application/web/services/confirm-swap/confirm-swap.service.types.ts
+++ b/src/application/web/services/confirm-swap/confirm-swap.service.types.ts
@@ -9,8 +9,8 @@ export interface IConfirmSwapService {
   navigateToCeloExplorer: () => Promise<void>;
   isSwapPerformingPopupThere: () => Promise<boolean>;
   isApproveCompleteNotificationThere: () => Promise<boolean>;
-  isRejectApprovalTransactionNotificationThere: () => Promise<boolean>;
-  isRejectSwapTransactionNotificationThere: () => Promise<boolean>;
+  isRejectApprovalTxNotificationThere: () => Promise<boolean>;
+  isRejectSwapTxNotificationThere: () => Promise<boolean>;
 }
 
 export interface IConfirmSwapServiceArgs extends IBaseServiceArgs {


### PR DESCRIPTION
### Description

Changed to swap with one token that gives opportunity to get the approval tx for sure - that improves stability of the test.

### Other changes
Shortened method names and simplified method.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
