### PR TITLE
fix: change amounts for exceeds amounts validations

### DIFF
--- a/specs/web/amount-validations/swap-in-amount.p1.spec.ts
+++ b/specs/web/amount-validations/swap-in-amount.p1.spec.ts
@@ -21,7 +21,7 @@ suite({
       name: 'Fill the "swap-in" with an amount that exceeds balance',
       testCaseId: "@T2a671992",
       test: async ({ web }) => {
-        await web.swap.fillForm({ fromAmount: "100" });
+        await web.swap.fillForm({ fromAmount: "700" });
         expect.soft(await web.swap.isContinueButtonThere()).toBeFalsy();
         expect(await web.swap.isAmountExceedValidationThere()).toBeTruthy();
       },

--- a/specs/web/amount-validations/swap-out-amount.p1.spec.ts
+++ b/specs/web/amount-validations/swap-out-amount.p1.spec.ts
@@ -21,7 +21,7 @@ suite({
       name: 'Fill the "swap-out" with an amount that exceeds balance',
       testCaseId: "@T88e163ac",
       test: async ({ web }) => {
-        await web.swap.fillForm({ toAmount: "100" });
+        await web.swap.fillForm({ toAmount: "700" });
         expect.soft(await web.swap.isContinueButtonThere()).toBeFalsy();
         expect(await web.swap.isAmountExceedValidationThere()).toBeTruthy();
       },


### PR DESCRIPTION
### Description

Balance is updated, so I had to change the amounts for the 'exceeds amount' validations

### Other changes

None

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
