### PR TITLE
feat: install playwright on prepare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18.20.0"
+        "node": ">=20.11.1"
       }
     },
     "node_modules/@adraffy/ens-normalize": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "codeCheck": "tsc && npm run linter",
     "build-synpress-cache": "npx synpress src/wallet-setups --force",
     "verify-env-config": "tsx src/tools/verify-env-config.tool.ts",
-    "prepare": "husky install",
+    "prepare": "husky install && npx playwright install --with-deps",
     "postinstall": "tsx src/tools/default-env-vars.tool.ts"
   },
   "engines": {


### PR DESCRIPTION
### Description

Added the Playwright installation on prepare - it means it will try to install playwright on `npm install` when it's not installed yet. Usually, it has to be triggered this way for the first `npm install` for a contributor.

### Other changes

None

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
