### PR TITLE
fix: reject approval tx test and create const for pairs

### DIFF
--- a/specs/web/swap/swapping-with-tx-rejection.p2.spec.ts
+++ b/specs/web/swap/swapping-with-tx-rejection.p2.spec.ts
@@ -2,6 +2,17 @@ import { expect } from "@fixtures/common/common.fixture";
 import { defaultSwapAmount, Token } from "@constants/token.constants";
 import { suite } from "@helpers/suite/suite.helper";
 
+const pairs = {
+  rejectApproval: {
+    from: Token.cEUR,
+    to: Token.cREAL,
+  },
+  rejectSwap: {
+    from: Token.CELO,
+    to: Token.cREAL,
+  },
+};
+
 suite({
   name: "Swap - Transaction rejection",
   beforeEach: async ({ web }) => {
@@ -9,11 +20,14 @@ suite({
   },
   tests: [
     {
-      name: `Reject approval tx (${Token.CELO}/${Token.cKES})`,
+      name: `Reject approval tx (${pairs.rejectApproval.from}/${pairs.rejectApproval.to})`,
       testCaseId: "@Td5aa1954",
       test: async ({ web }) => {
         await web.swap.fillForm({
-          tokens: { from: Token.CELO, to: Token.cKES },
+          tokens: {
+            from: pairs.rejectApproval.from,
+            to: pairs.rejectApproval.to,
+          },
           fromAmount: defaultSwapAmount,
         });
         await web.swap.start();
@@ -24,11 +38,14 @@ suite({
       },
     },
     {
-      name: `Reject swap tx (${Token.CELO}/${Token.cREAL})`,
+      name: `Reject swap tx (${pairs.rejectSwap.from}/${pairs.rejectSwap.to})`,
       testCaseId: "@T09fd373a",
       test: async ({ web }) => {
         await web.swap.fillForm({
-          tokens: { from: Token.CELO, to: Token.cREAL },
+          tokens: {
+            from: pairs.rejectSwap.from,
+            to: pairs.rejectSwap.to,
+          },
           fromAmount: defaultSwapAmount,
         });
         await web.swap.start();


### PR DESCRIPTION
### Description

Pretty frequently, we were getting failure on missing the approval tx for the `swapping-with-tx-rejection` spec. 
This fix prevents these failures by replacing the swap pair with cEUR/cREAL that is not used in the previous specs that gives us an opportunity to swap first time when there is no allowance.

### Other changes
Added `pairs` const for this spec file to re-use one the same token pairs for tests names and other usages.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
