### PR TITLE
fix: change to token to cUSD for cZAR test

### DIFF
--- a/specs/web/swap/swapping-by-token-pairs.p2.spec.ts
+++ b/specs/web/swap/swapping-by-token-pairs.p2.spec.ts
@@ -104,10 +104,7 @@ const testCases = [
   // cZAR
   {
     fromToken: Token.cZAR,
-    toToken: retryDataHelper.getRandomToken(Token.cZAR, [
-      Token.CELO,
-      Token.cUSD,
-    ]),
+    toToken: Token.cUSD,
     id: "@T4b1b444b",
     fromAmount: "0.1",
   },


### PR DESCRIPTION
### Description

We had a test to swap cZAR to cUSD or CELO randomly, but the price for this swap is 0.01 - when it's cZAR/CELO pair it's too small amount to verify the swap test result on the balance. Therefore, I replaced this to use only cUSD as a to token.

### Other changes

None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
