### PR TITLE
fix: timeout failures on the copy-address test because of absent of permissions to clipboard

### DIFF
--- a/.github/workflows/re-usable-test.yml
+++ b/.github/workflows/re-usable-test.yml
@@ -82,7 +82,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       APP_NAME: ${{ inputs.APP_NAME }}
       SPECS_TYPE: ${{ inputs.SPECS_TYPE }}

--- a/specs/app-mento/web/amounts/amounts.spec.ts
+++ b/specs/app-mento/web/amounts/amounts.spec.ts
@@ -88,27 +88,5 @@ suite({
         ).toBeTruthy();
       },
     },
-    {
-      name: `Trading limit error is shown when the 'Buy' amount exceeds limit`,
-      testCaseId: "",
-      test: async ({ web }) => {
-        const app = web.app.appMento;
-        await app.swap.swapInputs({
-          shouldReturnRates: false,
-          clicksOnButton: 2,
-        });
-        await app.swap.fillForm({
-          buyAmount: exceedsTradingLimitAmount,
-        });
-        expect
-          .soft(
-            await app.swap.waitForExceedsTradingLimitsNotification(timeouts.s),
-          )
-          .toBeTruthy();
-        expect(
-          await app.swap.waitForExceedsTradingLimitsButton(timeouts.s),
-        ).toBeTruthy();
-      },
-    },
   ],
 });

--- a/src/constants/timeouts.constants.ts
+++ b/src/constants/timeouts.constants.ts
@@ -7,7 +7,7 @@ export const timeouts = {
     return Number(TEST_TIMEOUT) ?? timeouts.minute * 3;
   },
   get testRun(): number {
-    return Number(TEST_RUN_TIMEOUT) ?? timeouts.minute * 55;
+    return Number(TEST_RUN_TIMEOUT) ?? timeouts.minute * 120;
   },
   get isOpenPage(): number {
     return this.l;

--- a/src/fixtures/test.fixture.ts
+++ b/src/fixtures/test.fixture.ts
@@ -23,6 +23,9 @@ export const testFixture = synpressFixture.extend<IApplicationFixtures>({
       metamaskHelper,
     });
     const web = await assembler.web();
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await web.browser.collectErrors();
+    await web.browser.attachErrors();
     await use(web);
   },
 

--- a/src/helpers/assembler/assember.ts
+++ b/src/helpers/assembler/assember.ts
@@ -19,10 +19,7 @@ import { AppName } from "@constants/apps.constants";
 import { MainGovernanceService } from "../../apps/governance/web/main/main.service";
 import { MainGovernancePage } from "../../apps/governance/web/main/main.page";
 import { envHelper } from "@helpers/env/env.helper";
-import { loggerHelper } from "@helpers/logger/logger.helper";
 import { HttpClient } from "@shared/api/http/http-client";
-
-const log = loggerHelper.get("Assembler");
 
 /**
  * 🚀 Goal
@@ -67,20 +64,20 @@ export class Assembler {
     this.httpClient = httpClient;
   }
 
+  //❗️ Assembling WEB only for a specified app by 'APP_NAME' variable in .env
   async web(): Promise<IWeb> {
     const baseDependencies: IBaseDependencies = {
       browser: this.browserHelper,
       metamaskHelper: this.metamaskHelper,
     };
-    log.warn(`❗️ Assembling WEB only for the '${this.appName}' app`);
     return {
       ...baseDependencies,
       app: this.apps.web[this.appName](this.elementFinder, baseDependencies),
     };
   }
 
+  //❗️ Assembling API only for a specified app by 'APP_NAME' variable in .env
   async api(): Promise<IApi> {
-    log.warn(`❗️ Assembling API only for the '${this.appName}' app`);
     return {
       httpClient: this.httpClient,
       // TODO: enable app assembling when there're use cases


### PR DESCRIPTION
### Description

The copy address test was stacking from the re-structure PR because of deleting the grantPermission call. Here I added this back to fix the test. 

### Other changes

*  I increased the test run timeout on CI and and Playwright config - previously it's been increased only on CI, therefore a couple of runs with higher execution time were failed because of closed test context.
* Added back the collect and attach console errors callings.
* Removed unused test
* Removed unused log

### Checklist before requesting a review

- [x] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
