### PR TITLE
fix: disable gov sequential regression job and rename it

### DIFF
--- a/.github/workflows/governance-regression-test.yml
+++ b/.github/workflows/governance-regression-test.yml
@@ -27,21 +27,22 @@ on:
         type: string
 
 jobs:
-  app_mento_regression_test:
+  app_governance_regression_test:
     name: "[Governance] ${{ matrix.name }} Regression Test Run"
     uses: ./.github/workflows/re-usable-test.yml
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: "Sequential"
-            specs_regex: "@regression,@sequential"
-            exclude_specs_regex: "@parallel"
-            is_parallel_run: "false"
-            is_mainnet: "false"
-            html_report_name: "app-mento-sequential-regression"
-            testomatio_title: "[Governance] Sequential-Regression"
-            notification_message: "[Governance] Sequential-Regression"
+          # Enable once we have sequential tests
+          # - name: "Sequential"
+          #   specs_regex: "@regression,@sequential"
+          #   exclude_specs_regex: "@parallel"
+          #   is_parallel_run: "false"
+          #   is_mainnet: "false"
+          #   html_report_name: "app-mento-sequential-regression"
+          #   testomatio_title: "[Governance] Sequential-Regression"
+          #   notification_message: "[Governance] Sequential-Regression"
           - name: "Parallel"
             specs_regex: "@regression,@parallel"
             exclude_specs_regex: "@sequential"


### PR DESCRIPTION
### Description

Disabled the Governance sequential regression job until we don't have any tests that have to run in sequential mode.

### Other changes

Renamed the Governance regression CI job.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
