### PR TITLE
fix: remove not a tradable token for axlEUROC swap test

### DIFF
--- a/specs/app-mento/web/swap/swap-by-token-pairs.spec.ts
+++ b/specs/app-mento/web/swap/swap-by-token-pairs.spec.ts
@@ -77,7 +77,7 @@ const testCases = [
     fromToken: Token.axlEUROC,
     toToken: retryDataHelper.getRandomToken(Token.axlEUROC, [
       Token.cEUR,
-      Token.eXOF,
+      Token.cUSD,
     ]),
     id: "T92258405",
   },


### PR DESCRIPTION
### Description

Removed the eXOF token from the randomTokens for the axlEUROC swap test to prevent failures on test execution.

### Other changes

None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
