### PR TITLE
fix: @governance __connect-wallet__ test method

### DIFF
--- a/specs/governance/web/wallet/connect-wallet.spec.ts
+++ b/specs/governance/web/wallet/connect-wallet.spec.ts
@@ -9,11 +9,11 @@ suite({
   tests: [
     {
       name: "Connect Metamask wallet",
-      // TODO: Add test case and paste an id
-      testCaseId: "",
+      testCaseId: "@T1eb92bd5",
       test: async ({ web }) => {
-        await web.app.governance.main.connectWalletByName(WalletName.Metamask);
-        expect(await web.app.governance.main.isWalletConnected()).toBeTruthy();
+        const app = web.app.governance.main;
+        await app.connectWalletByName(WalletName.Metamask);
+        expect(await app.isWalletConnected()).toBeTruthy();
       },
     },
   ],

--- a/src/apps/governance/web/main/main.service.ts
+++ b/src/apps/governance/web/main/main.service.ts
@@ -7,6 +7,7 @@ import {
 import { MainGovernancePage } from "./main.page";
 import { envHelper } from "@helpers/env/env.helper";
 import { CreateProposalPage } from "../create-proposal/create-proposal.page";
+import { timeouts } from "@constants/timeouts.constants";
 
 @ClassLog
 export class MainGovernanceService extends BaseService {
@@ -35,11 +36,21 @@ export class MainGovernanceService extends BaseService {
       await this.metamaskHelper.approveNewNetwork();
       await this.metamaskHelper.rejectSwitchNetwork();
     }
+    await this.waitForWalletToBeConnected();
   }
 
   async openCreateProposalPage(): Promise<void> {
     await this.page.createProposalButton.click();
     await this.createProposalPage.verifyIsOpen();
+  }
+
+  async waitForWalletToBeConnected(): Promise<boolean> {
+    return this.page.headerConnectWalletButton.waitUntilDisappeared(
+      timeouts.s,
+      {
+        throwError: false,
+      },
+    );
   }
 
   async isWalletConnected(): Promise<boolean> {


### PR DESCRIPTION
### Description

Sometimes, the Metamask connection is too long - therefore, we can failure on checking whether is wallet connected or not. I added the waiter for a connected wallet.

### Other changes

Added test case and its id to the connect wallet test.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
