### PR TITLE
fix: remove static wait and adjust click method to waitUntilEnabled __create-proposal__ @governance

### DIFF
--- a/src/apps/governance/web/create-proposal/create-proposal.service.ts
+++ b/src/apps/governance/web/create-proposal/create-proposal.service.ts
@@ -2,7 +2,6 @@ import { BaseService, IBaseServiceArgs } from "@shared/web/base/base.service";
 import { ClassLog } from "@decorators/logger.decorators";
 import { timeouts } from "@constants/timeouts.constants";
 import { CreateProposalPage } from "./create-proposal.page";
-import { waiterHelper } from "@helpers/waiter/waiter.helper";
 import { ProposalViewPage } from "../proposal-view/proposal-view.page";
 import { expect } from "@fixtures/test.fixture";
 
@@ -107,7 +106,6 @@ export class CreateProposalService extends BaseService {
   }: ICreateProposalArgs): Promise<void> {
     await this.page.proposalDetailsStage.titleInput.enterText(title);
     await this.fillDescription(description);
-    await waiterHelper.waitForAnimation();
     await this.page.nextButton.click();
     await this.verifyExecutionCodeStageOpened();
   }

--- a/src/apps/shared/web/elements/base/base.element.ts
+++ b/src/apps/shared/web/elements/base/base.element.ts
@@ -52,7 +52,7 @@ export abstract class BaseElement {
     const element = await this.element;
     await this.waitUntilDisplayed(timeout, { throwError });
     try {
-      if (await this.isEnabled()) {
+      if (await this.waitUntilEnabled(timeout, { throwError: false })) {
         await element.click({ force, timeout, clickCount: times });
       } else {
         logger.warn(

--- a/src/helpers/primitive/primitive.helper.ts
+++ b/src/helpers/primitive/primitive.helper.ts
@@ -26,10 +26,10 @@ class PrimitiveHelper {
       return Date.now().toString();
     },
 
-    generateRandom(length: number = 10): string {
+    generateRandom(length = 10): string {
       const chars =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-      let randomString: string = "";
+      let randomString = "";
       for (let i = 0; i < length; i++) {
         randomString += chars[Math.floor(Math.random() * chars.length)];
       }


### PR DESCRIPTION
### Description

Removed static wait before navigating to the next step of the creation proposal flow and adjusted the click method to wait untilEnabled.

### Other changes
None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
