### PR TITLE
fix: adjust __swap-with-tx-rejection__ tests @app-mento

### DIFF
--- a/specs/app-mento/web/swap/swap-with-tx-rejection.spec.ts
+++ b/specs/app-mento/web/swap/swap-with-tx-rejection.spec.ts
@@ -32,8 +32,9 @@ suite({
           },
           sellAmount: "30",
         });
-        await app.swap.page.approveButton.click();
-        await app.swap.confirm.rejectByType("approval");
+        await app.swap.proceedToConfirmationWithRejection({
+          rejectType: "approval",
+        });
         expect(
           await app.swap.confirm.isRejectApprovalTxNotificationThere(),
         ).toBeTruthy();
@@ -51,10 +52,9 @@ suite({
           },
           sellAmount: defaultSwapAmount,
         });
-        await app.swap.proceedToConfirmation();
-        await app.swap.confirm.page.verifyIsOpen();
-        await app.swap.confirm.page.swapButton.click();
-        await app.swap.confirm.rejectByType("swap");
+        await app.swap.proceedToConfirmationWithRejection({
+          rejectType: "swap",
+        });
         expect(
           await app.swap.confirm.isRejectSwapTxNotificationThere(),
         ).toBeTruthy();


### PR DESCRIPTION
### Description

Misclicking button to reject swap tx. Built a new method that handles that correctly.

### Other changes

_Describe any minor or "drive-by" changes here._

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
