### PR TITLE
fix: send notifications only on failures

### DIFF
--- a/.github/workflows/app-mento-smoke-test.yml
+++ b/.github/workflows/app-mento-smoke-test.yml
@@ -110,7 +110,7 @@ jobs:
 
   notification:
     needs: [smoke-test, report]
-    if: always()
+    if: failure()
     uses: ./.github/workflows/notification.yml
     with:
       JOB_STATUS: ${{ needs.smoke-test.result }}

--- a/.github/workflows/governance-smoke-test.yml
+++ b/.github/workflows/governance-smoke-test.yml
@@ -111,7 +111,7 @@ jobs:
 
   notification:
     needs: [smoke-test, report]
-    if: always()
+    if: failure()
     uses: ./.github/workflows/notification.yml
     with:
       JOB_STATUS: ${{ needs.smoke-test.result }}

--- a/.github/workflows/re-usable-test.yml
+++ b/.github/workflows/re-usable-test.yml
@@ -158,7 +158,7 @@ jobs:
 
   notification:
     needs: [test, report]
-    if: always()
+    if: failure()
     uses: ./.github/workflows/notification.yml
     with:
       JOB_STATUS: ${{ needs.test.result }}


### PR DESCRIPTION
### Description

Updated the Discord notifications sending rule - now it should be sent only on failures.

### Other changes

None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
