### PR TITLE
feat: adjust 'YES' __voting__ test @governance

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,8 +20,6 @@ export default defineConfig({
     browserName: "chromium",
     baseURL: envHelper.getBaseWebUrl(),
     trace: "retain-on-failure",
-    // TODO: turn on when fixed: https://github.com/microsoft/playwright/issues/14813
-    // video: "retain-on-failure",
   },
   projects: [
     {

--- a/specs/governance/web/proposal/voting.spec.ts
+++ b/specs/governance/web/proposal/voting.spec.ts
@@ -1,10 +1,14 @@
-import { magicStrings, TestTag } from "@constants/index";
+import { magicStrings, TestTag, timeouts } from "@constants/index";
 import { suite } from "@helpers/suite/suite.helper";
 import { WalletName } from "@shared/web/connect-wallet-modal/connect-wallet-modal.service";
-import { Vote } from "../../../../src/apps/governance/web/proposal-view/proposal-view.service";
+import {
+  ProposalState,
+  Vote,
+} from "../../../../src/apps/governance/web/proposal-view/proposal-view.service";
+import { expect } from "@fixtures/test.fixture";
 
 const testCases = [
-  { name: "'Yes' successfully", vote: Vote.Yes },
+  { name: "'Yes' successfully", vote: Vote.Yes, timeout: timeouts.minute * 6 },
   { name: "'No' successfully", vote: Vote.No },
   { name: "'Abstain' successfully", vote: Vote.Abstain },
 ];
@@ -21,14 +25,25 @@ suite({
     // TODO: Use the navigateToAppPage method once there's a correct proposalId gotten
     await app.main.openProposalByTitle(proposalData.title);
   },
-  tests: testCases.map(({ name, vote }) => ({
+  tests: testCases.map(({ name, vote, timeout }) => ({
     name,
     testCaseId: "",
+    timeout,
     test: async ({ web }) => {
       const app = web.app.governance;
 
       await app.proposalView.vote(vote);
       await app.proposalView.expectVote(vote);
+
+      if (name === testCases[0].name) {
+        await app.proposalView.waitForProposalState(
+          ProposalState.Succeeded,
+          timeout,
+        );
+        expect(await app.proposalView.getProposalState()).toBe(
+          ProposalState.Succeeded,
+        );
+      }
     },
   })),
 });

--- a/src/apps/governance/web/proposal-view/proposal-view.service.ts
+++ b/src/apps/governance/web/proposal-view/proposal-view.service.ts
@@ -80,6 +80,23 @@ export class ProposalViewService extends BaseService {
     return await this.page.proposalStateLabel.getText();
   }
 
+  async waitForProposalState(
+    state: ProposalState,
+    timeout = timeouts.m,
+  ): Promise<boolean> {
+    await this.page.proposalStateLabel.waitUntilDisplayed(timeouts.xs, {
+      errorMessage: "Proposal state is not displayed!",
+    });
+    return waiterHelper.wait(
+      async () => (await this.getProposalState()) === state,
+      timeout,
+      {
+        errorMessage: "Proposal state is not changed!",
+        throwError: false,
+      },
+    );
+  }
+
   async waitForLoadedVotingInfo(): Promise<boolean> {
     return this.page.votingInfoLoader.waitUntilDisappeared(timeouts.s, {
       errorMessage: "Voting info is not loaded!",

--- a/src/helpers/suite/suite.helper.ts
+++ b/src/helpers/suite/suite.helper.ts
@@ -36,7 +36,14 @@ export function suite({
       );
 
     tests.forEach(
-      ({ test, name: testName, disable, testCaseId, tags: rawTags = [] }) => {
+      ({
+        test,
+        name: testName,
+        disable,
+        testCaseId,
+        timeout,
+        tags: rawTags = [],
+      }) => {
         const tags = composeTags([...rawTags, testCaseId]);
 
         testUtils.isDisabled(disable)
@@ -52,8 +59,10 @@ export function suite({
           : testFixture(
               testName,
               { tag: tags },
-              async ({ web, metamaskHelper, api, contractHelper }) =>
-                await test({ web, metamaskHelper, api, contractHelper }),
+              async ({ web, metamaskHelper, api, contractHelper }) => {
+                timeout && testFixture.setTimeout(timeout);
+                await test({ web, metamaskHelper, api, contractHelper });
+              },
             );
       },
     );

--- a/src/helpers/suite/suite.types.ts
+++ b/src/helpers/suite/suite.types.ts
@@ -27,6 +27,7 @@ export interface ITest {
   test: (args: IExecution) => Promise<void>;
   disable?: IDisable;
   tags?: string[];
+  timeout?: number;
 }
 
 export interface IDisable {


### PR DESCRIPTION
### Description

Adjusted the 'YES' voting test to validate the 'succeeded' proposal state.

### Other changes

* Added the opportunity to set the testTimeout per test from the spec file.
* Removed unused TODO about turning on the video attachments.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
