### PR TITLE
fix: regression report duplication

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Upload report to GCS
         id: set-url
         run: |
-          # Create a unique run folder
-          RUN_FOLDER="run-${{ github.run_id }}-${{ github.run_number }}"
+          # Create a unique run folder with report name to distinguish between matrix jobs
+          RUN_FOLDER="run-${{ github.run_id }}-${{ github.run_number }}-${{ inputs.NAME }}"
 
           # Upload the report to GCS
           gsutil -m cp -r artifacts/reports/${{ inputs.NAME }}/* gs://${{ env.GCS_BUCKET_NAME }}/$RUN_FOLDER/


### PR DESCRIPTION
### Description

Fixed regression report duplication by creating a unique run folder with the report name to distinguish between matrix jobs. Regression test [run](https://github.com/mento-protocol/mento-automation-tests/actions/runs/17380747538).

### Other changes

None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
