### PR TITLE
fix: add retries for build-synpress-cache CI step and upload artifacts conditionally

### DIFF
--- a/.github/workflows/app-mento-smoke-test.yml
+++ b/.github/workflows/app-mento-smoke-test.yml
@@ -87,7 +87,7 @@ jobs:
           echo "CURRENT_DATETIME=$CURRENT_DATETIME" >> $GITHUB_ENV
 
       - name: Run Playwright tests
-        run: xvfb-run npx playwright test
+        run: xvfb-run npm run test
         env:
           TESTOMATIO_TITLE: "${{ inputs.TESTOMATIO_TITLE }} by ${{ github.actor }} at: ${{ env.CURRENT_DATETIME }}"
 

--- a/.github/workflows/governance-smoke-test.yml
+++ b/.github/workflows/governance-smoke-test.yml
@@ -88,7 +88,7 @@ jobs:
           echo "CURRENT_DATETIME=$CURRENT_DATETIME" >> $GITHUB_ENV
 
       - name: Run Playwright tests
-        run: xvfb-run npx playwright test
+        run: xvfb-run npm run test
         env:
           TESTOMATIO_TITLE: "${{ inputs.TESTOMATIO_TITLE }} by ${{ github.actor }} at: ${{ env.CURRENT_DATETIME }}"
 

--- a/.github/workflows/re-usable-test.yml
+++ b/.github/workflows/re-usable-test.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: xvfb-run npx synpress src/wallet-setups
+          command: xvfb-run build-synpress-cache
 
       - name: Set current datetime
         run: |

--- a/.github/workflows/re-usable-test.yml
+++ b/.github/workflows/re-usable-test.yml
@@ -132,8 +132,6 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          retry_wait_seconds: 15
-          retry_on: error
           command: xvfb-run npx synpress src/wallet-setups
 
       - name: Set current datetime

--- a/.github/workflows/re-usable-test.yml
+++ b/.github/workflows/re-usable-test.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Run Playwright tests
         id: test-run
-        run: xvfb-run npx playwright test
+        run: xvfb-run npm run test
         env:
           TESTOMATIO_TITLE: "${{ inputs.TESTOMATIO_TITLE }} by ${{ github.actor }} at: ${{ env.CURRENT_DATETIME }}"
 

--- a/.github/workflows/re-usable-test.yml
+++ b/.github/workflows/re-usable-test.yml
@@ -146,7 +146,7 @@ jobs:
           TESTOMATIO_TITLE: "${{ inputs.TESTOMATIO_TITLE }} by ${{ github.actor }} at: ${{ env.CURRENT_DATETIME }}"
 
       - name: Upload Playwright report
-        if: ${{ steps.test-run.outcome != 'skipped' && ((inputs.HTML_REPORT_GENERATION == 'true') || (inputs.HTML_REPORT_GENERATION == 'onFailure')) }}
+        if: ${{ steps.test-run.outcome != 'skipped' && ((inputs.HTML_REPORT_GENERATION == 'true') || (failure() && inputs.HTML_REPORT_GENERATION == 'onFailure')) }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.HTML_REPORT_NAME }}

--- a/.github/workflows/re-usable-test.yml
+++ b/.github/workflows/re-usable-test.yml
@@ -135,12 +135,13 @@ jobs:
           echo "CURRENT_DATETIME=$CURRENT_DATETIME" >> $GITHUB_ENV
 
       - name: Run Playwright tests
+        id: test-run
         run: xvfb-run npx playwright test
         env:
           TESTOMATIO_TITLE: "${{ inputs.TESTOMATIO_TITLE }} by ${{ github.actor }} at: ${{ env.CURRENT_DATETIME }}"
 
       - name: Upload Playwright report
-        if: ${{ (inputs.HTML_REPORT_GENERATION == 'true') || (failure() && inputs.HTML_REPORT_GENERATION == 'onFailure') }}
+        if: ${{ steps.test-run.outcome != 'skipped' && ((inputs.HTML_REPORT_GENERATION == 'true') || (inputs.HTML_REPORT_GENERATION == 'onFailure')) }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.HTML_REPORT_NAME }}

--- a/.github/workflows/re-usable-test.yml
+++ b/.github/workflows/re-usable-test.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           timeout_minutes: 3
           max_attempts: 3
-          command: xvfb-run build-synpress-cache
+          command: xvfb-run npm run build-synpress-cache
 
       - name: Set current datetime
         run: |

--- a/.github/workflows/re-usable-test.yml
+++ b/.github/workflows/re-usable-test.yml
@@ -127,7 +127,14 @@ jobs:
         run: npm run codeCheck
 
       - name: Build Synpress cache
-        run: xvfb-run npx synpress src/wallet-setups
+        id: synpress-cache
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          retry_wait_seconds: 15
+          retry_on: error
+          command: xvfb-run npx synpress src/wallet-setups
 
       - name: Set current datetime
         run: |

--- a/src/wallet-setups/basic.setup.ts
+++ b/src/wallet-setups/basic.setup.ts
@@ -13,6 +13,5 @@ const networkDetails = envHelper.isMainnet()
 export default defineWalletSetup(password, async (context, walletPage) => {
   const metamask = new MetaMask(context, walletPage, password);
   await metamask.importWallet(seed);
-  throw new Error("test");
   await metamask.addNetwork(networkDetails);
 });

--- a/src/wallet-setups/basic.setup.ts
+++ b/src/wallet-setups/basic.setup.ts
@@ -13,5 +13,6 @@ const networkDetails = envHelper.isMainnet()
 export default defineWalletSetup(password, async (context, walletPage) => {
   const metamask = new MetaMask(context, walletPage, password);
   await metamask.importWallet(seed);
+  throw new Error("test");
   await metamask.addNetwork(networkDetails);
 });


### PR DESCRIPTION
### Description

Sometimes, when we set up the Metamask wallet using the `build-synpress-cache`, it fails flakily (2/5).
Therefore, I used a new CI action that allows retrying CI steps.

### Other changes

Started uploading the artifacts conditionally. The dependency is the test-run step, if it's skipped - the artifacts will not try to upload.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
