### PR TITLE
feat: add loading state check __swap-by-amount-types__

### DIFF
--- a/specs/app-mento/web/swap/swap-by-amount-types.spec.ts
+++ b/specs/app-mento/web/swap/swap-by-amount-types.spec.ts
@@ -23,7 +23,7 @@ suite({
           tokens: { sell: tokens.from, buy: tokens.to },
           sellAmount: defaultSwapAmount,
         });
-        await app.swap.start();
+        await app.swap.start({ shouldExpectLoading: true });
         await app.main.expectIncreasedBalance({
           initialBalance,
           tokenName: tokens.to,
@@ -40,7 +40,7 @@ suite({
           tokens: { sell: tokens.from, buy: tokens.to },
           buyAmount: defaultSwapAmount,
         });
-        await app.swap.start();
+        await app.swap.start({ shouldExpectLoading: true });
         await app.main.expectIncreasedBalance({
           initialBalance: initialBalance,
           tokenName: tokens.to,

--- a/specs/app-mento/web/wallet/wallet-modal.spec.ts
+++ b/specs/app-mento/web/wallet/wallet-modal.spec.ts
@@ -32,7 +32,7 @@ suite({
         await app.main.openConnectWalletModal();
         await app.main.connectWalletModal.close();
         expect
-          .soft(await app.main.connectWalletModal.page.isNotOpen())
+          .soft(await app.main.connectWalletModal.page.isClosed())
           .toBeTruthy();
         expect(await app.main.page.isOpen()).toBeTruthy();
       },

--- a/src/apps/app-mento/web/confirm-swap/confirm-swap.page.ts
+++ b/src/apps/app-mento/web/confirm-swap/confirm-swap.page.ts
@@ -7,6 +7,8 @@ export class ConfirmSwapPage extends BasePage {
     super(ef);
   }
 
+  loadingLabel = new Label(this.ef.dataTestId("loadingLabel"));
+
   sellAmountLabel = new Label(this.ef.dataTestId("sellAmountLabel"));
   buyAmountLabel = new Label(this.ef.dataTestId("buyAmountLabel"));
 

--- a/src/apps/app-mento/web/swap/swap.page.ts
+++ b/src/apps/app-mento/web/swap/swap.page.ts
@@ -25,7 +25,7 @@ export class SwapPage extends BasePage {
   selectTokenToBuyLabel = new Button(
     this.ef.role("button", { name: "Select token to buy" }),
   );
-  headerLabel = new Label(this.ef.text("Swap"));
+  headerLabel = new Label(this.ef.text("Swap", { exact: false }).first());
   slippageButton = new Button(this.ef.dataTestId("slippageButton"));
   swapInputsButton = new Button(this.ef.dataTestId("swapInputsButton"));
   loadingLabel = new Label(this.ef.dataTestId("loadingLabel"));
@@ -59,7 +59,12 @@ export class SwapPage extends BasePage {
     this.ef.text("amount exceeds the current trading limit"),
   );
 
-  staticElements = [this.headerLabel];
+  staticElements = [
+    this.headerLabel,
+    this.swapButton,
+    this.buyAmountInput,
+    this.sellAmountInput,
+  ];
 }
 
 export interface ITokenOptions extends Record<string, Button> {

--- a/src/apps/app-mento/web/swap/swap.service.ts
+++ b/src/apps/app-mento/web/swap/swap.service.ts
@@ -89,7 +89,9 @@ export class SwapService extends BaseService {
     throw new Error(`Invalid reject type: ${rejectType}`);
   }
 
-  async start(): Promise<void> {
+  async start({
+    shouldExpectLoading = false,
+  }: { shouldExpectLoading?: boolean } = {}): Promise<void> {
     await this.confirm.verifyNoValidMedianCase();
     if (await this.page.approveButton.isDisplayed()) {
       log.debug(
@@ -102,7 +104,9 @@ export class SwapService extends BaseService {
       );
       await this.page.swapButton.click();
       await this.confirm.page.verifyIsOpen();
-      await this.confirm.confirmSwapTx();
+      await this.confirm.confirmSwapTx({ shouldExpectLoading });
+      await this.confirm.page.verifyIsClosed({ timeout: timeouts.s });
+      await this.page.verifyIsOpen({ timeout: timeouts.s });
     }
   }
 

--- a/src/apps/shared/web/base/base.page.ts
+++ b/src/apps/shared/web/base/base.page.ts
@@ -19,11 +19,12 @@ export abstract class BasePage {
     let { retry = 0 } = options;
     const { timeout = timeouts.isOpenPage, shouldWaitForExist = false } =
       options;
-    const isDisplayedPromises = this.staticElements.map(element => {
-      return shouldWaitForExist
+    const isDisplayedPromises = this.staticElements.map(element =>
+      shouldWaitForExist
         ? element.waitUntilExist(timeout, { throwError: false })
-        : element.waitUntilDisplayed(timeout, { throwError: false });
-    });
+        : element.waitUntilDisplayed(timeout, { throwError: false }),
+    );
+
     do {
       const result = promiseHelper.allTrue(isDisplayedPromises);
       if (result) {
@@ -33,7 +34,7 @@ export abstract class BasePage {
     return false;
   }
 
-  async isNotOpen(options: IIsOpenOpts = {}): Promise<boolean> {
+  async isClosed(options: IIsOpenOpts = {}): Promise<boolean> {
     let { retry = 0 } = options;
     const { timeout = timeouts.isOpenPage } = options;
     const isDisplayedPromises = this.staticElements.map(element => {
@@ -60,7 +61,7 @@ export abstract class BasePage {
   }
 
   async verifyIsClosed(opts: IIsOpenOpts = {}): Promise<void> {
-    if (!(await this.isNotOpen(opts))) {
+    if (!(await this.isClosed(opts))) {
       const errorMessage = `'${this.constructor.name.replace(
         "Po",
         "",

--- a/src/apps/shared/web/base/base.page.ts
+++ b/src/apps/shared/web/base/base.page.ts
@@ -17,12 +17,15 @@ export abstract class BasePage {
 
   async isOpen(options: IIsOpenOpts = {}): Promise<boolean> {
     let { retry = 0 } = options;
-    const { timeout = timeouts.isOpenPage, shouldWaitForExist = false } =
-      options;
+    const {
+      timeout = timeouts.isOpenPage,
+      shouldWaitForExist = false,
+      shouldLog = true,
+    } = options;
     const isDisplayedPromises = this.staticElements.map(element =>
       shouldWaitForExist
-        ? element.waitUntilExist(timeout, { throwError: false })
-        : element.waitUntilDisplayed(timeout, { throwError: false }),
+        ? element.waitUntilExist(timeout, { throwError: false, shouldLog })
+        : element.waitUntilDisplayed(timeout, { throwError: false, shouldLog }),
     );
 
     do {
@@ -76,4 +79,5 @@ export interface IIsOpenOpts {
   retry?: number;
   timeout?: number;
   shouldWaitForExist?: boolean;
+  shouldLog?: boolean;
 }

--- a/src/apps/shared/web/elements/base/base.element.ts
+++ b/src/apps/shared/web/elements/base/base.element.ts
@@ -11,7 +11,7 @@ import {
 import { waiterHelper } from "@helpers/waiter/waiter.helper";
 import { timeouts } from "@constants/timeouts.constants";
 
-const logger = loggerHelper.get("BaseElement");
+const log = loggerHelper.get("BaseElement");
 
 export abstract class BaseElement {
   protected constructor(protected element: Locator) {}
@@ -28,7 +28,7 @@ export abstract class BaseElement {
       return await this.element.isEnabled({ timeout });
     } catch (error) {
       const errorMessage = `Can't check for enabled on '${this.element}' element.\nDetails: ${error.message}`;
-      logger.error(errorMessage);
+      log.error(errorMessage);
       if (throwError) throw new Error(errorMessage);
     }
   }
@@ -47,7 +47,7 @@ export abstract class BaseElement {
       if (await this.isEnabled()) {
         await this.element.click({ timeout, force, clickCount: times });
       } else {
-        logger.warn(
+        log.warn(
           `Element with '${this.element}' is disabled - force clicking...`,
         );
         await this.element.click({ force: true, timeout, clickCount: times });
@@ -55,7 +55,7 @@ export abstract class BaseElement {
     } catch (error) {
       const errorMessage = `Can't click on '${this.element}' element.\nDetails: ${error.message}`;
       if (throwError) throw new Error(errorMessage);
-      logger.error(errorMessage);
+      log.error(errorMessage);
     }
   }
 
@@ -67,7 +67,7 @@ export abstract class BaseElement {
       return await this.element.textContent({ timeout });
     } catch (error) {
       const errorMessage = `Can't get text on '${this.element}' element'.\nDetails: ${error.message}`;
-      logger.error(errorMessage);
+      log.error(errorMessage);
       if (throwError) throw new Error(errorMessage);
     }
   }
@@ -80,7 +80,7 @@ export abstract class BaseElement {
       return await this.element.inputValue({ timeout });
     } catch (error) {
       const errorMessage = `Can't get value on '${this.element}' element'.\nDetails: ${error.message}`;
-      logger.error(errorMessage);
+      log.error(errorMessage);
       if (throwError) throw new Error(errorMessage);
     }
   }
@@ -94,7 +94,7 @@ export abstract class BaseElement {
       return (await this.element).innerHTML({ timeout });
     } catch (error) {
       const errorMessage = `Can't get HTML on element with '${this.element}' locator.\nError details: ${error.message}`;
-      logger.error(errorMessage);
+      log.error(errorMessage);
       if (throwError) throw new Error(errorMessage);
     }
   }
@@ -107,7 +107,7 @@ export abstract class BaseElement {
       return await this.element.hover({ timeout });
     } catch (error) {
       const errorMessage = `Can't hover on '${this.element}' element.\nDetails: ${error.message}`;
-      logger.error(errorMessage);
+      log.error(errorMessage);
       if (throwError) throw new Error(errorMessage);
     }
   }
@@ -116,7 +116,8 @@ export abstract class BaseElement {
     timeout: number,
     {
       throwError = true,
-      errorMessage = "Failed to wait for element to display",
+      errorMessage = `Failed to wait for '${this.element}' element to display`,
+      shouldLog = true,
     }: IWaitUntilDisplayed = {},
   ): Promise<boolean> {
     try {
@@ -124,9 +125,10 @@ export abstract class BaseElement {
       return true;
     } catch (error) {
       const errorLogType = throwError ? "error" : "warn";
-      logger[errorLogType](`${errorMessage}: ${this.element}`);
+      const message = `${errorMessage}: ${error}`;
+      if (shouldLog) log[errorLogType](`${message}`);
       if (throwError) {
-        throw { ...error, message: `${errorMessage}: ${error.message}}` };
+        throw { ...error, message: `${message}` };
       }
       return false;
     }
@@ -136,16 +138,19 @@ export abstract class BaseElement {
     timeout: number,
     {
       throwError = true,
-      errorMessage = "Failed to wait for element to disappear",
+      shouldLog = true,
+      errorMessage = `Failed to wait for '${this.element}' element to disappear`,
     }: IWaitUntilDisplayed = {},
   ): Promise<boolean> {
+    const logType = throwError ? "error" : "warn";
     try {
       await this.element.waitFor({ timeout, state: "hidden" });
       return true;
     } catch (error) {
-      logger.error(`${errorMessage}: ${this.element}`);
+      const message = `${errorMessage}: ${error.message}`;
+      if (shouldLog) log[logType](`${message}`);
       if (throwError) {
-        throw { ...error, message: `${errorMessage}: ${error.message}}` };
+        throw { ...error, message };
       }
       return false;
     }
@@ -155,6 +160,7 @@ export abstract class BaseElement {
     timeout: number,
     {
       throwError = true,
+      shouldLog = true,
       errorMessage = "Failed to wait for element to exist",
     }: IWaitUntilDisplayed = {},
   ): Promise<boolean> {
@@ -162,7 +168,7 @@ export abstract class BaseElement {
       await this.element.waitFor({ timeout, state: "attached" });
       return true;
     } catch (error) {
-      logger.error(`${errorMessage}: ${this.element}`);
+      if (shouldLog) log.error(`${errorMessage}: ${this.element}`);
       if (throwError) {
         throw { ...error, message: `${errorMessage}: ${error.message}}` };
       }
@@ -174,15 +180,19 @@ export abstract class BaseElement {
     timeout: number,
     {
       throwError = true,
-      errorMessage = "Failed to wait for element to be enabled",
+      shouldLog = true,
+      errorMessage = `Failed to wait for '${this.element}' element to be enabled`,
     }: IWaitUntilDisplayed = {},
   ): Promise<boolean> {
+    const logType = throwError ? "error" : "warn";
     try {
       return await waiterHelper.wait(async () => this.isEnabled(), timeout);
     } catch (error) {
-      logger.warn(`${errorMessage}: ${this.element}`);
+      const message = `${errorMessage}: ${error}`;
+
+      if (shouldLog) log[logType](`${message}`);
       if (throwError) {
-        throw { ...error, message: `${errorMessage}: ${error.message}}` };
+        throw { ...error, message };
       }
       return false;
     }

--- a/src/apps/shared/web/elements/base/base.element.types.ts
+++ b/src/apps/shared/web/elements/base/base.element.types.ts
@@ -1,6 +1,7 @@
 export interface IWaitUntilDisplayed {
   errorMessage?: string;
   throwError?: boolean;
+  shouldLog?: boolean;
 }
 
 export interface IBasePe {


### PR DESCRIPTION
### Description

We had a bug where the loading state started disappearing once a user confirmed the swap TX.
Therefore, I added an optional `shouldExpectLoading` flag; if it is true, then a new method will be triggered to expect a loading state during confirmation of the swap TX.

### Other changes

* Added new `checkDuring` method to simplify test logic.
* Updated logs visibility.
* Updated some method names.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
