### PR TITLE
feat: add new and update old __trading limit__ tests

### DIFF
--- a/specs/app-mento/web/amounts/amounts.spec.ts
+++ b/specs/app-mento/web/amounts/amounts.spec.ts
@@ -69,20 +69,39 @@ suite({
       },
     },
     {
-      name: `Trading limit error is shown when the 'Sell' amount exceeds limit`,
+      name: `Exceeds trading limit error is shown when token has a trading limit`,
       testCaseId: "",
       test: async ({ web }) => {
         const app = web.app.appMento;
         await app.swap.swapInputs({
           shouldReturnRates: false,
-          clicksOnButton: 2,
         });
         await app.swap.fillForm({
           sellAmount: exceedsTradingLimitAmount,
         });
+        expect
+          .soft(
+            await app.swap.waitForExceedsTradingLimitsNotification(timeouts.m),
+          )
+          .toBeTruthy();
         expect(
-          await app.swap.waitForExceedsTradingLimitsNotification(timeouts.m),
+          await app.swap.waitForExceedsTradingLimitsButton(timeouts.s),
         ).toBeTruthy();
+      },
+    },
+    {
+      name: `Missing trading limit error is shown when token doesn't have a trading limit`,
+      testCaseId: "",
+      test: async ({ web }) => {
+        const app = web.app.appMento;
+        await app.swap.fillForm({
+          sellAmount: exceedsTradingLimitAmount,
+        });
+        expect
+          .soft(
+            await app.swap.waitForMissingTradingLimitsNotification(timeouts.m),
+          )
+          .toBeTruthy();
         expect(
           await app.swap.waitForExceedsTradingLimitsButton(timeouts.s),
         ).toBeTruthy();

--- a/src/apps/app-mento/web/swap/swap.page.ts
+++ b/src/apps/app-mento/web/swap/swap.page.ts
@@ -58,6 +58,9 @@ export class SwapPage extends BasePage {
   exceedsTradingLimitNotificationLabel = new Label(
     this.ef.text("amount exceeds the current trading limit"),
   );
+  missingTradingLimitNotificationLabel = new Label(
+    this.ef.text("Cannot buy more than"),
+  );
 
   staticElements = [
     this.headerLabel,

--- a/src/apps/app-mento/web/swap/swap.service.ts
+++ b/src/apps/app-mento/web/swap/swap.service.ts
@@ -284,6 +284,19 @@ export class SwapService extends BaseService {
     );
   }
 
+  async waitForMissingTradingLimitsNotification(
+    timeout: number,
+  ): Promise<boolean> {
+    return waiterHelper.wait(
+      async () => this.page.missingTradingLimitNotificationLabel.isDisplayed(),
+      timeout,
+      {
+        throwError: false,
+        errorMessage: "'Missing trading limits' notification is not displayed",
+      },
+    );
+  }
+
   async waitForExceedsTradingLimitsButton(timeout: number): Promise<boolean> {
     return waiterHelper.wait(
       async () => this.page.swapsExceedsLimitsButton.isDisplayed(),


### PR DESCRIPTION
### Description

Added new and updated old trading limit tests. There's a new notification toast when a token doesn't have a trading limit. Therefore, I added a new test and updated the old one, where I used a workaround of clicking on the `swapInputs` button twice to successfully swap inputs - now it works without it.

### Other changes

None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
