### PR TITLE
fix: apply click method timeout for inside methods usages and remove unused awaits

### DIFF
--- a/src/apps/app-mento/web/confirm-swap/confirm-swap.service.ts
+++ b/src/apps/app-mento/web/confirm-swap/confirm-swap.service.ts
@@ -88,7 +88,7 @@ export class ConfirmSwapService extends BaseService {
 
   private async rejectApprovalTx(): Promise<void> {
     if (
-      await this.page.approveButton.waitUntilDisplayed(timeouts.s, {
+      await this.page.approveButton.waitForDisplayed(timeouts.s, {
         throwError: false,
       })
     ) {
@@ -100,12 +100,12 @@ export class ConfirmSwapService extends BaseService {
 
   private async rejectSwapTx(): Promise<void> {
     if (
-      await this.page.approveButton.waitUntilDisplayed(timeouts.s, {
+      await this.page.approveButton.waitForDisplayed(timeouts.s, {
         throwError: false,
       })
     ) {
       await this.metamask.confirmTransaction();
-      await this.page.approveCompleteNotificationLabel.waitUntilDisplayed(
+      await this.page.approveCompleteNotificationLabel.waitForDisplayed(
         timeouts.xl,
         { errorMessage: "Approve tx notification is not displayed" },
       );
@@ -122,7 +122,7 @@ export class ConfirmSwapService extends BaseService {
   async expectSuccessApprovalNotification(): Promise<void> {
     expect
       .soft(
-        await this.page.approveCompleteNotificationLabel.waitUntilDisplayed(
+        await this.page.approveCompleteNotificationLabel.waitForDisplayed(
           timeouts.xl,
           {
             errorMessage: "Approve tx notification is not displayed",
@@ -136,7 +136,7 @@ export class ConfirmSwapService extends BaseService {
   async expectSuccessSwapNotification(): Promise<void> {
     expect
       .soft(
-        await this.page.swapCompleteNotificationLabel.waitUntilDisplayed(
+        await this.page.swapCompleteNotificationLabel.waitForDisplayed(
           timeouts.m,
           {
             errorMessage: "Swap tx notification is not displayed",
@@ -166,21 +166,21 @@ export class ConfirmSwapService extends BaseService {
   }
 
   async isApproveCompleteNotificationThere(): Promise<boolean> {
-    return this.page.approveCompleteNotificationLabel.waitUntilDisplayed(
+    return this.page.approveCompleteNotificationLabel.waitForDisplayed(
       timeouts.xl,
       { throwError: false },
     );
   }
 
   async isRejectApprovalTxNotificationThere(): Promise<boolean> {
-    return this.page.rejectApprovalTransactionNotificationLabel.waitUntilDisplayed(
+    return this.page.rejectApprovalTransactionNotificationLabel.waitForDisplayed(
       timeouts.s,
       { throwError: false },
     );
   }
 
   async isRejectSwapTxNotificationThere(): Promise<boolean> {
-    return this.page.rejectSwapTransactionNotificationLabel.waitUntilDisplayed(
+    return this.page.rejectSwapTransactionNotificationLabel.waitForDisplayed(
       timeouts.s,
       { throwError: false },
     );

--- a/src/apps/app-mento/web/swap/swap.service.ts
+++ b/src/apps/app-mento/web/swap/swap.service.ts
@@ -214,7 +214,7 @@ export class SwapService extends BaseService {
   }
 
   async getInvalidPairTooltipText(): Promise<string> {
-    await this.page.invalidPairTooltip.waitUntilDisplayed(timeouts.s);
+    await this.page.invalidPairTooltip.waitForDisplayed(timeouts.s);
     return this.page.invalidPairTooltip.getText();
   }
 
@@ -224,7 +224,7 @@ export class SwapService extends BaseService {
       force: true,
       times: 2,
     });
-    await this.page.considerKeepNotificationLabel.waitUntilDisplayed(
+    await this.page.considerKeepNotificationLabel.waitForDisplayed(
       timeouts.xs,
       { throwError: false },
     );
@@ -254,19 +254,19 @@ export class SwapService extends BaseService {
   }
 
   async isAmountRequiredValidationThere(): Promise<boolean> {
-    return this.page.amountRequiredButton.waitUntilDisplayed(timeouts.s, {
+    return this.page.amountRequiredButton.waitForDisplayed(timeouts.s, {
       throwError: false,
     });
   }
 
   async isAmountExceedValidationThere(): Promise<boolean> {
-    return this.page.insufficientBalanceButton.waitUntilDisplayed(timeouts.s, {
+    return this.page.insufficientBalanceButton.waitForDisplayed(timeouts.s, {
       throwError: false,
     });
   }
 
   async isErrorValidationThere(): Promise<boolean> {
-    return this.page.errorButton.waitUntilDisplayed(timeouts.s, {
+    return this.page.errorButton.waitForDisplayed(timeouts.s, {
       throwError: false,
     });
   }
@@ -401,9 +401,7 @@ export class SwapService extends BaseService {
       timeout: timeouts.s,
     });
     await this.selectTokenModalPage.verifyIsClosed();
-    await this.page
-      .getSelectedTokenLabel(token)
-      .waitUntilDisplayed(timeouts.xxs);
+    await this.page.getSelectedTokenLabel(token).waitForDisplayed(timeouts.xxs);
   }
 
   private async selectTokens(args: ISelectTokensArgs): Promise<void> {

--- a/src/apps/governance/web/create-proposal/create-proposal.service.ts
+++ b/src/apps/governance/web/create-proposal/create-proposal.service.ts
@@ -77,7 +77,7 @@ export class CreateProposalService extends BaseService {
   async verifyProposalCreation(): Promise<void> {
     expect
       .soft(
-        await this.page.proposalSuccessToast.toast.waitUntilDisplayed(
+        await this.page.proposalSuccessToast.toast.waitForDisplayed(
           timeouts.xl,
           {
             throwError: false,
@@ -91,25 +91,25 @@ export class CreateProposalService extends BaseService {
   }
 
   async verifyCreationPopupAppeared(): Promise<boolean> {
-    return this.page.confirmProposalPopup.waitUntilDisplayed(timeouts.m, {
+    return this.page.confirmProposalPopup.waitForDisplayed(timeouts.m, {
       errorMessage: "'Confirm proposal' popup is not appeared!",
     });
   }
 
   async verifyCreationPopupDisappeared(): Promise<boolean> {
-    return this.page.confirmProposalPopup.waitUntilDisappeared(timeouts.m, {
+    return this.page.confirmProposalPopup.waitForDisappeared(timeouts.m, {
       errorMessage: "'Confirm proposal' popup is not disappeared!",
     });
   }
 
   async verifyReviewStageOpened(): Promise<boolean> {
-    return this.page.reviewStage.stageLabel.waitUntilDisplayed(timeouts.s, {
+    return this.page.reviewStage.stageLabel.waitForDisplayed(timeouts.s, {
       errorMessage: "'Review' stage is not opened!",
     });
   }
 
   async verifyExecutionCodeStageOpened(): Promise<boolean> {
-    return this.page.executionCodeStage.stageLabel.waitUntilDisplayed(
+    return this.page.executionCodeStage.stageLabel.waitForDisplayed(
       timeouts.s,
       {
         errorMessage: "'Execution code' stage is not opened!",

--- a/src/apps/governance/web/main/main.service.ts
+++ b/src/apps/governance/web/main/main.service.ts
@@ -73,26 +73,23 @@ export class MainGovernanceService extends BaseService {
 
   async openContractAddressesSection(): Promise<void> {
     await this.page.contractAddressesSection.click();
-    await this.page.contractAddresseLinkButtons.governor.waitUntilDisplayed(
+    await this.page.contractAddresseLinkButtons.governor.waitForDisplayed(
       timeouts.xxs,
       { errorMessage: "Contract addresses section is not opened" },
     );
   }
 
   async waitForWalletToBeConnected(): Promise<boolean> {
-    return this.page.headerConnectWalletButton.waitUntilDisappeared(
-      timeouts.s,
-      {
-        throwError: false,
-      },
-    );
+    return this.page.headerConnectWalletButton.waitForDisappeared(timeouts.s, {
+      throwError: false,
+    });
   }
 
   async waitForProposalByTitle(title: string): Promise<boolean> {
     return waiterHelper.retry(
       async () => {
         await this.browser.refresh();
-        return (await this.page.getProposalByTitle(title)).waitUntilDisplayed(
+        return (await this.page.getProposalByTitle(title)).waitForDisplayed(
           timeouts.m,
           { throwError: false },
         );

--- a/src/apps/governance/web/proposal-view/proposal-view.service.ts
+++ b/src/apps/governance/web/proposal-view/proposal-view.service.ts
@@ -24,10 +24,10 @@ export class ProposalViewService extends BaseService {
     { shouldConfirmTx = true }: { shouldConfirmTx?: boolean } = {},
   ): Promise<void> {
     await this.page.voteButtons[vote].click();
-    await this.page.waitingForConfirmationLabel.waitUntilDisplayed(timeouts.s, {
+    await this.page.waitingForConfirmationLabel.waitForDisplayed(timeouts.s, {
       errorMessage: "'Waiting for confirmation label' is not displayed!",
     });
-    await this.page.waitingForConfirmationDescriptionLabel.waitUntilDisplayed(
+    await this.page.waitingForConfirmationDescriptionLabel.waitForDisplayed(
       timeouts.s,
       {
         errorMessage:
@@ -43,7 +43,7 @@ export class ProposalViewService extends BaseService {
   }
 
   async getTotalVotes(): Promise<number> {
-    await this.page.totalVotesLabel.waitUntilDisplayed(timeouts.s, {
+    await this.page.totalVotesLabel.waitForDisplayed(timeouts.s, {
       errorMessage: "Total votes label is not displayed!",
     });
     const rawTotalVotesText = await this.page.totalVotesLabel.getText();
@@ -64,7 +64,7 @@ export class ProposalViewService extends BaseService {
   }
 
   async getUsedVoteOption(): Promise<Vote> {
-    await this.page.usedVoteOptionButton.waitUntilDisplayed(timeouts.s, {
+    await this.page.usedVoteOptionButton.waitForDisplayed(timeouts.s, {
       errorMessage: "Used vote option button is not displayed!",
     });
     const vote = await this.page.usedVoteOptionButton.getText();
@@ -87,7 +87,7 @@ export class ProposalViewService extends BaseService {
     state: ProposalState,
     timeout = timeouts.m,
   ): Promise<boolean> {
-    await this.page.proposalStateLabel.waitUntilDisplayed(timeouts.xs, {
+    await this.page.proposalStateLabel.waitForDisplayed(timeouts.xs, {
       errorMessage: "Proposal state is not displayed!",
     });
     return waiterHelper.wait(
@@ -101,7 +101,7 @@ export class ProposalViewService extends BaseService {
   }
 
   async waitForLoadedVotingInfo(): Promise<boolean> {
-    return this.page.votingInfoLoader.waitUntilDisappeared(timeouts.s, {
+    return this.page.votingInfoLoader.waitForDisappeared(timeouts.s, {
       errorMessage: "Voting info is not loaded!",
     });
   }
@@ -112,14 +112,14 @@ export class ProposalViewService extends BaseService {
   ): Promise<boolean> {
     return await this.page
       .getParticipantAddressLabel(address)
-      .waitUntilDisplayed(timeout, {
+      .waitForDisplayed(timeout, {
         errorMessage: "Participant address is not displayed!",
         throwError: false,
       });
   }
 
   async isVoteCastSuccessfully(timeout = timeouts.m): Promise<boolean> {
-    return this.page.voteCastSuccessfullyNotificationLabel.waitUntilDisplayed(
+    return this.page.voteCastSuccessfullyNotificationLabel.waitForDisplayed(
       timeout,
       {
         errorMessage: "Vote cast successfully notification is not displayed!",
@@ -129,12 +129,9 @@ export class ProposalViewService extends BaseService {
   }
 
   async isVoteCastFailed(timeout = timeouts.s): Promise<boolean> {
-    return this.page.voteCastFailedNotificationLabel.waitUntilDisplayed(
-      timeout,
-      {
-        errorMessage: "Vote cast failed notification is not displayed!",
-      },
-    );
+    return this.page.voteCastFailedNotificationLabel.waitForDisplayed(timeout, {
+      errorMessage: "Vote cast failed notification is not displayed!",
+    });
   }
 
   async expectProposalSuccessfully({

--- a/src/apps/governance/web/voting-power/voting-power.service.ts
+++ b/src/apps/governance/web/voting-power/voting-power.service.ts
@@ -44,7 +44,7 @@ export class VotingPowerService extends BaseService {
     }
     expect
       .soft(
-        await this.page.lockUpdatedSuccessfullyNotificationLabel.waitUntilDisplayed(
+        await this.page.lockUpdatedSuccessfullyNotificationLabel.waitForDisplayed(
           timeouts.s,
           {
             errorMessage: "Top-up success notification is not displayed!",
@@ -59,14 +59,14 @@ export class VotingPowerService extends BaseService {
     buttonName: "approveMentoButton" | "topUpLockButton",
     { throwError = false }: { throwError?: boolean } = {},
   ): Promise<boolean> {
-    return this.page[buttonName].waitUntilDisplayed(timeouts.xs, {
+    return this.page[buttonName].waitForDisplayed(timeouts.xs, {
       errorMessage: `${buttonName} is not there!`,
       throwError,
     });
   }
 
   async verifyConfirmationPopupIsClosed() {
-    await this.page.topUpLockPopupDescriptionLabel.waitUntilDisappeared(
+    await this.page.topUpLockPopupDescriptionLabel.waitForDisappeared(
       timeouts.s,
       {
         errorMessage: "Lock confirmation popup is not closed!",
@@ -75,7 +75,7 @@ export class VotingPowerService extends BaseService {
   }
 
   async verifyConfirmationPopupIsOpened() {
-    await this.page.topUpLockPopupDescriptionLabel.waitUntilDisplayed(
+    await this.page.topUpLockPopupDescriptionLabel.waitForDisplayed(
       timeouts.s,
       {
         errorMessage: "Lock confirmation popup is not displayed!",
@@ -123,7 +123,7 @@ export class VotingPowerService extends BaseService {
 
   async enterAmount(amount: string): Promise<void> {
     await this.page.lockAmountInput.enterText(amount);
-    await this.page.enterAmountButton.waitUntilDisappeared(timeouts.xs);
+    await this.page.enterAmountButton.waitForDisappeared(timeouts.xs);
   }
 
   async getCurrentLockValues(): Promise<{ veMento: number; mento: number }> {

--- a/src/apps/shared/web/base/base.page.ts
+++ b/src/apps/shared/web/base/base.page.ts
@@ -24,8 +24,8 @@ export abstract class BasePage {
     } = options;
     const isDisplayedPromises = this.staticElements.map(element =>
       shouldWaitForExist
-        ? element.waitUntilExist(timeout, { throwError: false, shouldLog })
-        : element.waitUntilDisplayed(timeout, { throwError: false, shouldLog }),
+        ? element.waitForExist(timeout, { throwError: false, shouldLog })
+        : element.waitForDisplayed(timeout, { throwError: false, shouldLog }),
     );
 
     do {
@@ -41,7 +41,7 @@ export abstract class BasePage {
     let { retry = 0 } = options;
     const { timeout = timeouts.isOpenPage } = options;
     const isDisplayedPromises = this.staticElements.map(element => {
-      return element.waitUntilDisappeared(timeout, { throwError: false });
+      return element.waitForDisappeared(timeout, { throwError: false });
     });
     do {
       const result = promiseHelper.allTrue(isDisplayedPromises);

--- a/src/apps/shared/web/celo-scan/celo-scan.service.ts
+++ b/src/apps/shared/web/celo-scan/celo-scan.service.ts
@@ -15,11 +15,9 @@ export class CeloScanService extends BaseService {
 
   async openLogs(txUrl: string): Promise<void> {
     await this.browser.openUrl(`${txUrl}#eventlog`);
-    await this.page.logRows
-      .getElementByIndex(0)
-      .waitUntilDisplayed(timeouts.xs, {
-        errorMessage: "Logs section is not opened!",
-      });
+    await this.page.logRows.getElementByIndex(0).waitForDisplayed(timeouts.xs, {
+      errorMessage: "Logs section is not opened!",
+    });
   }
 
   async getLogRowContent(logRowIndex: number): Promise<string> {

--- a/src/apps/shared/web/elements/base/base.element.ts
+++ b/src/apps/shared/web/elements/base/base.element.ts
@@ -90,7 +90,7 @@ export abstract class BaseElement {
     throwError = true,
   }: IGetTextParams = {}): Promise<string> {
     try {
-      await this.waitUntilDisplayed(timeout, { throwError });
+      await this.waitForDisplayed(timeout, { throwError });
       return this.element.innerHTML({ timeout });
     } catch (error) {
       const errorMessage = `Can't get HTML on element with '${this.element}' locator.\nError details: ${error.message}`;
@@ -112,7 +112,7 @@ export abstract class BaseElement {
     }
   }
 
-  async waitUntilDisplayed(
+  async waitForDisplayed(
     timeout: number,
     {
       throwError = true,
@@ -134,7 +134,7 @@ export abstract class BaseElement {
     }
   }
 
-  async waitUntilDisappeared(
+  async waitForDisappeared(
     timeout: number,
     {
       throwError = true,
@@ -156,7 +156,7 @@ export abstract class BaseElement {
     }
   }
 
-  async waitUntilExist(
+  async waitForExist(
     timeout: number,
     {
       throwError = true,
@@ -176,7 +176,7 @@ export abstract class BaseElement {
     }
   }
 
-  async waitUntilEnabled(
+  async waitForEnabled(
     timeout: number,
     {
       throwError = true,

--- a/src/apps/shared/web/elements/base/base.element.ts
+++ b/src/apps/shared/web/elements/base/base.element.ts
@@ -17,7 +17,7 @@ export abstract class BaseElement {
   protected constructor(protected element: Locator) {}
 
   async isDisplayed(): Promise<boolean> {
-    return await this.element.isVisible();
+    return this.element.isVisible();
   }
 
   async isEnabled({
@@ -34,7 +34,7 @@ export abstract class BaseElement {
   }
 
   async getAttribute(attribute: string): Promise<string> {
-    return (await this.element).getAttribute(attribute);
+    return this.element.getAttribute(attribute);
   }
 
   async click({
@@ -44,7 +44,7 @@ export abstract class BaseElement {
     times,
   }: IClickParams = {}): Promise<void> {
     try {
-      if (await this.isEnabled()) {
+      if (await this.isEnabled({ timeout })) {
         await this.element.click({ timeout, force, clickCount: times });
       } else {
         log.warn(
@@ -64,7 +64,7 @@ export abstract class BaseElement {
     throwError = true,
   }: IGetValueParams = {}): Promise<string> {
     try {
-      return await this.element.textContent({ timeout });
+      return this.element.textContent({ timeout });
     } catch (error) {
       const errorMessage = `Can't get text on '${this.element}' element'.\nDetails: ${error.message}`;
       log.error(errorMessage);
@@ -77,7 +77,7 @@ export abstract class BaseElement {
     throwError = true,
   }: IGetValueParams = {}): Promise<string> {
     try {
-      return await this.element.inputValue({ timeout });
+      return this.element.inputValue({ timeout });
     } catch (error) {
       const errorMessage = `Can't get value on '${this.element}' element'.\nDetails: ${error.message}`;
       log.error(errorMessage);
@@ -91,7 +91,7 @@ export abstract class BaseElement {
   }: IGetTextParams = {}): Promise<string> {
     try {
       await this.waitUntilDisplayed(timeout, { throwError });
-      return (await this.element).innerHTML({ timeout });
+      return this.element.innerHTML({ timeout });
     } catch (error) {
       const errorMessage = `Can't get HTML on element with '${this.element}' locator.\nError details: ${error.message}`;
       log.error(errorMessage);
@@ -104,7 +104,7 @@ export abstract class BaseElement {
     timeout,
   }: IHoverParams = {}): Promise<void> {
     try {
-      return await this.element.hover({ timeout });
+      return this.element.hover({ timeout });
     } catch (error) {
       const errorMessage = `Can't hover on '${this.element}' element.\nDetails: ${error.message}`;
       log.error(errorMessage);
@@ -186,7 +186,7 @@ export abstract class BaseElement {
   ): Promise<boolean> {
     const logType = throwError ? "error" : "warn";
     try {
-      return await waiterHelper.wait(async () => this.isEnabled(), timeout);
+      return waiterHelper.wait(async () => this.isEnabled(), timeout);
     } catch (error) {
       const message = `${errorMessage}: ${error}`;
 


### PR DESCRIPTION
### Description

Updated the `click` method to use the passed timeout for all the inside methods. The `isEnabled` inside didn't pass the timeout, which was causing flaky failures for create-proposal button clicks.

### Other changes

* Removed all the unused awaits from the `base.element.ts` file
* Renamed the wait methods to make them shorter

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
