### PR TITLE
fix: add retry for __wallet-modal__ tests @app-mento

### DIFF
--- a/specs/app-mento/web/wallet/wallet-modal.spec.ts
+++ b/specs/app-mento/web/wallet/wallet-modal.spec.ts
@@ -1,4 +1,5 @@
 import { TestTag } from "@constants/test.constants";
+import { timeouts } from "@constants/timeouts.constants";
 import { expect } from "@fixtures/test.fixture";
 import { suite } from "@helpers/suite/suite.helper";
 
@@ -31,10 +32,14 @@ suite({
         const app = web.app.appMento;
         await app.main.openConnectWalletModal();
         await app.main.connectWalletModal.close();
-        expect
-          .soft(await app.main.connectWalletModal.page.isClosed())
-          .toBeTruthy();
-        expect(await app.main.page.isOpen()).toBeTruthy();
+        expect(
+          await app.main.connectWalletModal.page.isClosed({
+            timeout: timeouts.xxs,
+          }),
+        ).toBeTruthy();
+        expect(
+          await app.main.page.isOpen({ timeout: timeouts.xxs }),
+        ).toBeTruthy();
       },
     },
   ],

--- a/src/apps/shared/web/connect-wallet-modal/connect-wallet-modal.service.ts
+++ b/src/apps/shared/web/connect-wallet-modal/connect-wallet-modal.service.ts
@@ -2,6 +2,7 @@ import { ClassLog } from "@decorators/logger.decorators";
 import { timeouts } from "@constants/timeouts.constants";
 import { BaseService, IBaseServiceArgs } from "@shared/web/base/base.service";
 import { ConnectWalletModalPage } from "./connect-wallet-modal.page";
+import { waiterHelper } from "@helpers/waiter/waiter.helper";
 
 @ClassLog
 export class ConnectWalletModalService extends BaseService {
@@ -18,10 +19,20 @@ export class ConnectWalletModalService extends BaseService {
   }
 
   async close(): Promise<void> {
-    return this.page.closeButton.click({
-      force: true,
-      timeout: timeouts.xxs,
-    });
+    await waiterHelper.retry(
+      async () => {
+        await this.page.closeButton.click({
+          force: true,
+          timeout: timeouts.xxs,
+        });
+        return this.page.isClosed({ timeout: timeouts.xxs });
+      },
+      3,
+      {
+        errorMessage: "Failed to close connect wallet modal",
+        throwError: false,
+      },
+    );
   }
 }
 


### PR DESCRIPTION
### Description

Fixed the flaky `wallet-modal` test by adding a retry when clicking a button.

### Other changes

None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
