### PR TITLE
fix: flaky confirming TXs

### DIFF
--- a/src/apps/app-mento/web/confirm-swap/confirm-swap.service.ts
+++ b/src/apps/app-mento/web/confirm-swap/confirm-swap.service.ts
@@ -30,7 +30,8 @@ export class ConfirmSwapService extends BaseService {
   }
 
   async confirmApprovalTx(): Promise<void> {
-    await this.page.approveButton.click({ timeout: timeouts.s });
+    await this.page.approveButton.waitForDisplayed(timeouts.s);
+    await this.page.approveButton.click({ timeout: timeouts.xxs });
     await this.metamask.confirmTransaction();
     await this.expectSuccessApprovalNotification();
   }
@@ -38,8 +39,9 @@ export class ConfirmSwapService extends BaseService {
   async confirmSwapTx({
     shouldExpectLoading = false,
   }: { shouldExpectLoading?: boolean } = {}): Promise<void> {
-    await this.page.swapButton.click({ timeout: timeouts.s });
+    await this.page.swapButton.waitForDisplayed(timeouts.s);
     await this.verifyTradingSuspendedCase();
+    await this.page.swapButton.click({ timeout: timeouts.xxs });
     await this.metamask.confirmTransaction();
     if (shouldExpectLoading) await this.expectLoadingDuringTxConfirmation();
     await this.expectSuccessSwapNotification();


### PR DESCRIPTION
### Description

Fixed flaky confirming TXs when trading is suspended. Previously, we had this error thrown only once a user clicks the 'swap' button - now it throws when a user is just being redirected to the 'Confirm Swap' page, and the 'Swap' button is not active.

### Other changes

None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
