### PR TITLE
fix: remove celo from random tokens

### DIFF
--- a/specs/app-mento/web/swap/swap-by-token-pairs.spec.ts
+++ b/specs/app-mento/web/swap/swap-by-token-pairs.spec.ts
@@ -86,7 +86,6 @@ const testCases = [
   {
     fromToken: Token.cGHS,
     toToken: retryDataHelper.getRandomToken(Token.cGHS, [
-      Token.CELO,
       Token.cUSD,
       Token.USDC,
       Token.USDT,
@@ -97,10 +96,7 @@ const testCases = [
   // cGBP
   {
     fromToken: Token.cGBP,
-    toToken: retryDataHelper.getRandomToken(Token.cGBP, [
-      Token.CELO,
-      Token.cUSD,
-    ]),
+    toToken: Token.cUSD,
     id: "T22f94bbb",
   },
   // cZAR
@@ -113,19 +109,13 @@ const testCases = [
   // cCAD
   {
     fromToken: Token.cCAD,
-    toToken: retryDataHelper.getRandomToken(Token.cCAD, [
-      Token.CELO,
-      Token.cUSD,
-    ]),
+    toToken: Token.cUSD,
     id: "T0869d367",
   },
   // cAUD
   {
     fromToken: Token.cAUD,
-    toToken: retryDataHelper.getRandomToken(Token.cAUD, [
-      Token.CELO,
-      Token.cUSD,
-    ]),
+    toToken: Token.cUSD,
     id: "T1d46dc17",
   },
   // cCHF


### PR DESCRIPTION
### Description

Removed the CELO token as an option from the getRandomToken function call to avoid flakiness. When a buy token is CELO and the amount is small (the default swap amount is 0.01), we fail the balance checking assertion. We expected the balance to increase, but it actually decreased because the amount is small, and we need to pay for gas with CELO.

### Other changes

None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
