### PR TITLE
fix: current __top-up__ test @governance

### DIFF
--- a/src/apps/governance/web/voting-power/voting-power.page.ts
+++ b/src/apps/governance/web/voting-power/voting-power.page.ts
@@ -26,9 +26,6 @@ export class VotingPowerPage extends BasePage {
 
   // actionButton = new Button(this.ef.pw.dataTestId("actionButton"));
 
-  topUpLockPopupDescriptionLabel = new Label(
-    this.ef.text("Continue in wallet"),
-  );
   lockUpdatedSuccessfullyNotificationLabel = new Label(
     this.ef.text("Lock updated successfully"),
   );
@@ -43,6 +40,11 @@ export class VotingPowerPage extends BasePage {
     expirationDateLabel: new Label(
       this.ef.dataTestId("existingLockExpirationDateLabel"),
     ),
+  };
+
+  actionPopup = {
+    continueInWalletLabel: new Label(this.ef.text("Continue in wallet")),
+    confirmingLabel: new Label(this.ef.text("Confirming...")),
   };
 
   staticElements = [this.headerLabel];


### PR DESCRIPTION
### Description

Recently, the logic of topping up has been updated - now it does not close the confirmation pop-up to proceed with topping up once a user has confirmed the approval tx.
It's the same behavior that we have in the multi-locks PR.

### Other changes
None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
