### PR TITLE
refactor: remove redundant balance check to accelerate tests __swap-default__

### DIFF
--- a/src/apps/app-mento/web/main/main.service.ts
+++ b/src/apps/app-mento/web/main/main.service.ts
@@ -6,7 +6,6 @@ import { Token } from "@constants/token.constants";
 import { waiterHelper } from "@helpers/waiter/waiter.helper";
 import { timeouts } from "@constants/timeouts.constants";
 import { expect } from "@fixtures/test.fixture";
-import { testHelper } from "@helpers/test/test.helper";
 import { primitiveHelper } from "@helpers/primitive/primitive.helper";
 import { MainAppMentoPage } from "./main.page";
 import {
@@ -207,7 +206,6 @@ export class MainAppMentoService extends BaseService {
     shouldCloseSettings = false,
     tokenToCheck = Token.USDm,
     throwError = true,
-    shouldVerifyBalanceLoadingError = true,
   }: IWaitForBalanceToLoadOptions = {}): Promise<boolean> {
     shouldOpenSettings && (await this.openSettings());
     const isBalanceLoaded = waiterHelper.wait(
@@ -215,9 +213,6 @@ export class MainAppMentoService extends BaseService {
         const result = await this.settings.page
           .getTokenBalanceLabelByName(tokenToCheck)
           .isDisplayed();
-        if (!result && shouldVerifyBalanceLoadingError) {
-          await this.verifyErrorRetrievingBalances();
-        }
         result && log.info("Balance is loaded successfully!");
         return result;
       },
@@ -230,36 +225,6 @@ export class MainAppMentoService extends BaseService {
     );
     shouldCloseSettings && (await this.closeWalletSettings());
     return isBalanceLoaded;
-  }
-
-  private async verifyErrorRetrievingBalances(): Promise<void> {
-    return (await this.isErrorRetrievingBalances())
-      ? testHelper.skipInRuntime(
-          {
-            reason: "Error retrieving account balances",
-          },
-          "'Error retrieving account balances' case",
-        )
-      : log.debug("Error retrieving account balances is not defined");
-  }
-
-  private async isErrorRetrievingBalances({
-    retryCount = 1,
-  }: IsErrorRetrievingBalances = {}): Promise<boolean> {
-    return waiterHelper.retry(
-      async () => {
-        return this.browser.hasConsoleErrorsMatchingText(
-          "Failed to retrieve balances",
-        );
-      },
-      retryCount,
-      {
-        interval: timeouts.xxxxs,
-        throwError: false,
-        continueWithException: true,
-        errorMessage: "Checking for a 'error retrieving account balances' case",
-      },
-    );
   }
 
   async expectUpdatedBalanceOnUi({
@@ -283,7 +248,6 @@ interface IWaitForBalanceToLoadOptions {
   tokenToCheck?: Token;
   shouldOpenSettings?: boolean;
   shouldCloseSettings?: boolean;
-  shouldVerifyBalanceLoadingError?: boolean;
   throwError?: boolean;
 }
 
@@ -296,10 +260,6 @@ interface IGetTokenBalanceByNameOpts {
   shouldOpenSettings?: boolean;
   shouldCloseSettings?: boolean;
   throwError?: boolean;
-}
-
-interface IsErrorRetrievingBalances {
-  retryCount?: number;
 }
 
 export interface IMainServiceArgs extends IBaseServiceArgs {


### PR DESCRIPTION
### Description

This PR removes the redundant balance check because the error message used to define this error no longer exists on App-Mento. Removing it saves up to 3 seconds per test.

### Other changes

None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
