### PR TITLE
fix: testnet test execution

### DIFF
--- a/specs/app-mento/web/swap/swap-default.spec.ts
+++ b/specs/app-mento/web/swap/swap-default.spec.ts
@@ -5,7 +5,6 @@ import { testHelper } from "@helpers/test/test.helper";
 
 const isFork = envHelper.isFork();
 const swapAmount = getDefaultSwapAmount({ isFork });
-// TODO: Change to default tokens once CELO route is available
 const tokens = { sell: Token.USDm, buy: Token.GBPm };
 // Skip that assertion because loading is so fast on forks
 const shouldExpectLoading = isFork ? false : true;

--- a/src/apps/app-mento/web/main/main.service.ts
+++ b/src/apps/app-mento/web/main/main.service.ts
@@ -15,7 +15,7 @@ import {
 } from "@shared/web/connect-wallet-modal/connect-wallet-modal.service";
 import { SettingsService } from "../settings/settings.service";
 import { SwitchNetworksPage } from "../settings/switch-networks.page";
-import { ChainName } from "@helpers/env/env.helper";
+import { ChainName, envHelper } from "@helpers/env/env.helper";
 
 const log = loggerHelper.get("MainAppMentoService");
 
@@ -126,13 +126,34 @@ export class MainAppMentoService extends BaseService {
     await this.openConnectWalletModalFromHeader();
     await this.connectWalletModal.selectWalletByName(walletName);
     await this.metamask.connectWallet();
+    !envHelper.isMainnet() && (await this.overrideToTestnet());
+  }
+
+  // When your wallet has only testnet, it still points to mainnet by default
+  // This method overrides it to testnet to be able to ignore UI for testing on testnet
+  async overrideToTestnet() {
+    await this.enableTestnetMode({ shouldIgnoreUI: true });
+    const currentUrl = await this.browser.getCurrentPageUrl();
+    const newUrl = currentUrl.includes("celo")
+      ? currentUrl.replace("celo", "celo-sepolia")
+      : currentUrl.replace("monad", "monad-testnet");
+    log.debug(`Overriding to testnet: ${newUrl}`);
+    await this.browser.openUrl(newUrl);
   }
 
   async isTestnetModeEnabled(): Promise<boolean> {
     return this.settings.page.testnetModeCheckbox.isChecked();
   }
 
-  async enableTestnetMode(): Promise<void> {
+  async enableTestnetMode({
+    shouldIgnoreUI = false,
+  }: { shouldIgnoreUI?: boolean } = {}): Promise<void> {
+    if (shouldIgnoreUI) {
+      return this.browser.setLocalStorage({
+        key: "mento:testnet-mode",
+        value: "true",
+      });
+    }
     await this.openSettings();
     if (await this.isTestnetModeEnabled()) {
       log.debug("Testnet mode is already enabled!");


### PR DESCRIPTION
### Description

This PR enables instant testing on the testnet chain without interacting with the UI. The new flow is supposed to be that even if a user has only a testnet chain, it will still set the Celo Mainnet by default, which wasn't the previous behavior.
Therefore, I added a new method that overrides to the testnet, ignoring the UI, so we can keep testing on the testnet without adding new UI interactions.

### Other changes

Removed unused TODO.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
