### PR TITLE
fix: balance check by contract function

### DIFF
--- a/specs/app-mento/web/swap/swap-by-token-pairs.spec.ts
+++ b/specs/app-mento/web/swap/swap-by-token-pairs.spec.ts
@@ -259,7 +259,7 @@ testHelper.runSuite({
           test: async ({ web, contractHelper }: IExecution) => {
             const app = web.app.appMento;
             const initialBalance =
-              await contractHelper.governance.getBalanceByTokenSymbol({
+              await contractHelper.governance.getRawBalanceByTokenSymbol({
                 walletAddress: testWalletAddresses.main,
                 tokenSymbol: buyToken,
               });

--- a/specs/squid-router/web/swap-by-token-pairs.spec.ts
+++ b/specs/squid-router/web/swap-by-token-pairs.spec.ts
@@ -101,12 +101,12 @@ testHelper.runSuite({
           const { sellToken, buyToken } = testCase;
 
           const initialSellBalance =
-            await web.contract.governance.getBalanceByTokenSymbol({
+            await web.contract.governance.getRawBalanceByTokenSymbol({
               walletAddress: testWalletAddresses.main,
               tokenSymbol: sellToken,
             });
           const initialBuyBalance =
-            await web.contract.governance.getBalanceByTokenSymbol({
+            await web.contract.governance.getRawBalanceByTokenSymbol({
               walletAddress: testWalletAddresses.main,
               tokenSymbol: buyToken,
             });

--- a/src/apps/shared/contracts/base/base.contract.ts
+++ b/src/apps/shared/contracts/base/base.contract.ts
@@ -43,6 +43,20 @@ export class BaseContract {
     }
   }
 
+  async getRawBalanceByTokenSymbol({
+    walletAddress,
+    tokenSymbol,
+  }: IGetBalanceByTokenSymbolParams): Promise<bigint> {
+    const tokenAddress = await this.getTokenAddress(tokenSymbol);
+    const contract = new ethers.Contract(
+      tokenAddress,
+      this.getErc20Abi(),
+      this.provider,
+    );
+    const rawBalance = await contract.balanceOf(walletAddress);
+    return BigInt(rawBalance.toString());
+  }
+
   async getBalanceByTokenSymbol({
     walletAddress,
     tokenSymbol,

--- a/src/apps/shared/web/base/base.service.ts
+++ b/src/apps/shared/web/base/base.service.ts
@@ -89,18 +89,17 @@ export class BaseService {
     initialBalance,
     shouldIncrease,
   }: IExpectUpdatedBalanceArgs): Promise<void> {
-    let currentBalance = null;
+    let currentBalanceWei = 0n;
     await waiterHelper.retry(
       async () => {
-        currentBalance = await this.contract.governance.getBalanceByTokenSymbol(
-          {
+        currentBalanceWei =
+          await this.contract.governance.getRawBalanceByTokenSymbol({
             walletAddress,
             tokenSymbol,
-          },
-        );
+          });
         return shouldIncrease
-          ? currentBalance > initialBalance
-          : currentBalance < initialBalance;
+          ? currentBalanceWei > initialBalance
+          : currentBalanceWei < initialBalance;
       },
       3,
       {
@@ -111,8 +110,8 @@ export class BaseService {
       },
     );
     shouldIncrease
-      ? expect.soft(currentBalance).toBeGreaterThan(initialBalance)
-      : expect.soft(currentBalance).toBeLessThan(initialBalance);
+      ? expect.soft(currentBalanceWei).toBeGreaterThan(initialBalance)
+      : expect.soft(currentBalanceWei).toBeLessThan(initialBalance);
   }
 }
 
@@ -125,7 +124,7 @@ export interface IBaseServiceArgs {
 }
 
 interface IExpectUpdatedBalanceArgs {
-  initialBalance: number;
+  initialBalance: bigint;
   walletAddress: Address;
   tokenSymbol: TokenSymbol;
   shouldIncrease: boolean;


### PR DESCRIPTION
### Description
Balance checks in swap tests used Number(rawBalance) / 10 ** decimals, which loses precision for large token balances, so small real increases after a swap never showed up and retries failed. This PR compares on-chain balances as bigint (new getRawBalanceByTokenSymbol) in expectUpdatedBalance, and updates token-pair specs to snapshot initial balances that way.

Before: False “balance hasn’t increased” when the chain did move. After: Assertions match real wei-level changes.

### Other changes
None.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
