### PR TITLE
docs: add general docs for repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+Full documentation lives under **[docs/](docs/README.md)** (architecture, env, CI, forks, reporting). This file stays the short GitHub-facing guide.
+
+## PR healthcheck workflow
+
+The [PR Healthcheck](.github/workflows/pr-healthcheck-test.yml) workflow runs on **pull requests** (skips PRs that only change Markdown or `.gitignore`) and on **pushes to `main`**. It reads the **latest commit message** on the checked-out ref (`git log -1`) to decide which app and which tests to run. See [docs/contributing.md](docs/contributing.md) for the same tables with extra context.
+
+### App selection (put one of these in the commit message)
+
+| Tag             | Effect                 |
+| --------------- | ---------------------- |
+| `@app-mento`    | Run app-mento tests    |
+| `@governance`   | Run governance tests   |
+| `@squid-router` | Run squid-router tests |
+
+If none match, **app-mento** is used.
+
+### Spec scope (put one of these in the commit message)
+
+| Pattern           | Effect                                    |
+| ----------------- | ----------------------------------------- |
+| `__@regression__` | Grep for `@regression`                    |
+| `__@smoke__`      | Grep for `@smoke`                         |
+| `__@full__`       | Run all specs (`.*`)                      |
+| `__my-regex__`    | Use `my-regex` as Playwright `grep` value |
+
+If none match, the default is **`connect-wallet`**.
+
+### Combining tags
+
+Include both an app tag and a spec pattern in the same commit message when you need both (for example: `@governance __@smoke__`).
+
+## Code quality
+
+- `pnpm run verify:code` runs TypeScript (`tsc`) and ESLint; it is also run locally via the pre-commit hook.
+- **TypeScript `strict` mode** is not enabled yet. Turning it on surfaces a large number of issues (optional fixtures, `null` sentinels on class fields, `WebApp` unions, `catch` typing, and more). A dedicated migration PR should tackle that in stages (for example `strictNullChecks` plus fixture typing, then property initialization and catch blocks).
+
+## Dependency updates
+
+[Dependabot](.github/dependabot.yml) opens weekly update PRs for npm and GitHub Actions. Keep `@playwright/test` and the Playwright Docker image tag in CI workflows aligned when upgrading Playwright.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 ### Here you can find more detailed overview of [test automation](https://www.notion.so/mentolabs/Test-Automation-12da2148cc5c8010bae9cf8150e5c13f)
 
+## Documentation
+
+| Resource                           | Description                                             |
+| ---------------------------------- | ------------------------------------------------------- |
+| [docs/README.md](docs/README.md)   | Index of all technical docs in this repo                |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | PR healthcheck tags, hooks, Dependabot, TypeScript note |
+
 ## Pre-requisites
 
 - [node.js](https://nodejs.org/en) >= 22.14.0
@@ -56,9 +63,7 @@ brew install foundry
 
 ## Local test/s execution by mods:
 
-- _**headed**_ - with opening browser (command can be shortened to `pnpm t`)
-
-`pnpm run test`
+- _**headed**_ — default CLI run: `pnpm run test` or the short alias `pnpm t`
 
 - _**ui**_ - with opening browser in specified app with all devtools, traces, and other playwright features
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Documentation index
+
+Central documentation for **mento-automation-tests** — end-to-end and API-style tests for Mento Protocol web apps using Playwright, Synpress (MetaMask), and TypeScript.
+
+| Document                                                | Description                                              |
+| ------------------------------------------------------- | -------------------------------------------------------- |
+| [Overview](overview.md)                                 | Purpose, tech stack, applications under test             |
+| [Getting started](getting-started.md)                   | Prerequisites, install, Synpress cache, first run        |
+| [Environment variables](environment-variables.md)       | `.env`, validation, CI vs local                          |
+| [Project structure](project-structure.md)               | Repository layout and TypeScript path aliases            |
+| [Test architecture](test-architecture.md)               | Fixtures, assembler, suites, page objects and services   |
+| [Running tests](running-tests.md)                       | npm/pnpm scripts, filtering specs, timeouts, parallelism |
+| [CI and GitHub Actions](ci-github-actions.md)           | Workflows, reusable jobs, secrets, artifacts             |
+| [Fork and local chain](fork-and-local-chain.md)         | Anvil, Makefile, block explorer, fork data               |
+| [Logging and reporting](logging-and-reporting.md)       | log4js, HTML reports, Testomat                           |
+| [Tools and maintenance](tools-and-scripts.md)           | `src/tools`, cost calculator, housekeeping scripts       |
+| [Glossary and conventions](glossary-and-conventions.md) | Apps, chains, tags, naming                               |
+| [Contributing (extended)](contributing.md)              | PR checklist, healthcheck details, strict-mode note      |
+| [Troubleshooting](troubleshooting.md)                   | Common env, Synpress, CI, and lint issues                |
+
+The root [README](../README.md) stays the short entry point; [CONTRIBUTING](../CONTRIBUTING.md) covers contribution workflow and links here for depth.

--- a/docs/ci-github-actions.md
+++ b/docs/ci-github-actions.md
@@ -1,0 +1,57 @@
+# CI and GitHub Actions
+
+## Design
+
+- **`base-test.yml`** — reusable **workflow** (`workflow_call`) that installs dependencies, validates code, optionally prepares a fork, runs `pnpm run test`, uploads HTML artifacts, and on failure triggers **report** + **Discord notification**.
+- **Composite actions** under `.github/actions/` — **`install`**, **`validate`**, **`setup`** — keep job steps DRY.
+
+The test job runs inside **`mcr.microsoft.com/playwright:v*-jammy`** so browser dependencies match Playwright’s expectations. **`xvfb-run`** wraps the test command for headed MetaMask flows in headless CI.
+
+## Checkout behavior (`base-test.yml`)
+
+The workflow supports:
+
+1. **Same repo** — normal `actions/checkout` when the triggering repository is `mento-automation-tests`.
+2. **External caller** — when another repository triggers the workflow, checkout clones **`mento-protocol/mento-automation-tests`** at `main` (or `CHECKOUT_REF`) so `.github/actions/*` paths exist.
+3. **Explicit `CHECKOUT_REPOSITORY` / `CHECKOUT_REF`** — for custom cross-repo scenarios.
+
+## Workflows (by file)
+
+| Workflow                                                       | Role                                                                                                                                                                                                                        |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pr-healthcheck-test.yml`                                      | On **pull requests** (skips Markdown-only / `.gitignore`-only diffs) and **push to `main`**: parses **latest commit message** for app + spec regex, then calls `base-test`. Uses **concurrency** to cancel superseded runs. |
+| `specific-test.yml`                                            | **Manual** `workflow_dispatch` to run arbitrary app/spec/env/chain inputs via `base-test`.                                                                                                                                  |
+| `app-mento-smoke-test.yml`                                     | Callable smoke preset for app-mento (expects `CUSTOM_URL` from caller).                                                                                                                                                     |
+| `app-mento-regression-test.yml`                                | Callable regression for app-mento.                                                                                                                                                                                          |
+| `governance-smoke-test.yml` / `governance-regression-test.yml` | Callable governance suites.                                                                                                                                                                                                 |
+| `squid-router-regression-test.yml`                             | Callable squid-router regression.                                                                                                                                                                                           |
+| `report.yml`                                                   | Downloads HTML artifact, uploads to **GCS** (`mento-playwright-reports` bucket), exposes report URL output.                                                                                                                 |
+| `notification.yml`                                             | Posts **Discord** webhook on failure with job + report links.                                                                                                                                                               |
+
+Exact triggers (`on:`) for smoke/regression files may be `workflow_call` only — they are intended to be invoked from repo settings, other workflows, or the GitHub UI depending on org setup.
+
+## Secrets (typical)
+
+Referenced from `base-test.yml` and related workflows:
+
+| Secret                                                           | Use                                         |
+| ---------------------------------------------------------------- | ------------------------------------------- |
+| `E2E_TEST_SEED_PHRASE` / `E2E_TEST_WALLET_PASSWORD`              | Mapped to `SEED_PHRASE` / `WALLET_PASSWORD` |
+| `TESTOMAT_API_KEY`                                               | Testomat reporter                           |
+| `E2E_TEST_GCP_SA_KEY`                                            | Service account JSON for report upload      |
+| `DISCORD_TEST_RUN_WEBHOOK_ID` / `DISCORD_TEST_RUN_WEBHOOK_TOKEN` | Failure notifications                       |
+| `GOVERNANCE_TESTNET_API_KEY` / `GOVERNANCE_TESTNET_API_URL`      | Optional governance API tests               |
+
+Fork mode additionally uses Makefile + Foundry in the **install** / **setup** actions when `IS_FORK` is true.
+
+## Dependabot
+
+`.github/dependabot.yml` schedules **weekly** updates for **npm** and **github-actions**, with optional grouping for Playwright and TypeScript-ESLint packages.
+
+## PR healthcheck commit conventions
+
+Documented in [CONTRIBUTING](../CONTRIBUTING.md) and summarized here:
+
+- **App tags in commit message:** `@app-mento`, `@governance`, `@squid-router`
+- **Spec scope:** `__@smoke__`, `__@regression__`, `__@full__`, or `__<grep>__` for custom regex
+- Default if missing: **app-mento** + **`connect-wallet`**

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,47 @@
+# Contributing (extended)
+
+This file expands the root [CONTRIBUTING.md](../CONTRIBUTING.md) with pointers to the rest of the **docs/** tree.
+
+## Before you open a PR
+
+1. Run **`pnpm run verify:code`** (also enforced by Husky on commit).
+2. Ensure **`.env`** has valid **`APP_NAME`**, wallet secrets, and **`IS_MAINNET`** for any local runs you rely on (see [Environment variables](environment-variables.md)).
+3. If you change Playwright version, align **`@playwright/test`**, **`pnpm`**, and the **Playwright Docker image** tag in CI (see [CI and GitHub Actions](ci-github-actions.md)).
+
+## PR healthcheck (detailed)
+
+Behavior is implemented in [`.github/workflows/pr-healthcheck-test.yml`](../.github/workflows/pr-healthcheck-test.yml). Summary:
+
+- Triggers: **pull requests** (excluding Markdown-only / `.gitignore`-only diffs) and **push to `main`** with the same path filters.
+- **Concurrency:** new pushes cancel older runs for the same PR or ref.
+- **Commit message** on `HEAD` (`git log -1`) selects app + grep pattern.
+
+### App tags (in latest commit message)
+
+| Tag             | `APP_NAME`              |
+| --------------- | ----------------------- |
+| `@app-mento`    | `app-mento`             |
+| `@governance`   | `governance`            |
+| `@squid-router` | `squid-router`          |
+| _(none)_        | defaults to `app-mento` |
+
+### Spec patterns (in latest commit message)
+
+| Pattern           | `SPECS_REGEX` / grep |
+| ----------------- | -------------------- |
+| `__@regression__` | `@regression`        |
+| `__@smoke__`      | `@smoke`             |
+| `__@full__`       | `.*`                 |
+| `__foo__`         | `foo`                |
+| _(none)_          | `connect-wallet`     |
+
+Combine app + pattern in one message when needed, e.g. `@governance __@smoke__`.
+
+## Dependency and tooling policy
+
+- [Dependabot](../.github/dependabot.yml): weekly npm + GitHub Actions; review grouped PRs carefully.
+- Prefer **small, focused PRs** for test and fixture changes so bisect and revert stay easy.
+
+## TypeScript strict mode
+
+Full **`strict`** compilation is not enabled yet. A staged plan might include: fixture typing (`IExecution` vs `IApplicationFixtures`), `WebApp` narrowing helpers, `catch (e: unknown)` hygiene, and `| null` on intentionally deferred class fields. Track as a dedicated initiative.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,67 @@
+# Environment variables
+
+Variables are read from **`.env`** (via `dotenv` in `src/helpers/processEnv/processEnv.helper.ts`) and typed through `processEnv`. CI workflows set the same names as **job `env`** in `.github/workflows/base-test.yml`.
+
+## Validation before tests
+
+`pnpm run verify:env-config` runs `src/tools/verify-env-config.tool.ts` and **fails** if any of these are missing or empty:
+
+| Variable          | Role                                                      |
+| ----------------- | --------------------------------------------------------- |
+| `SEED_PHRASE`     | Mnemonic for test wallet                                  |
+| `WALLET_PASSWORD` | MetaMask password                                         |
+| `IS_MAINNET`      | `true` / `false` — drives mainnet vs testnet chain config |
+| `APP_NAME`        | `app-mento` \| `governance` \| `squid-router`             |
+
+**Note:** The auto-generated `.env` template in `src/constants/default-env-variables.constants.ts` historically used a line like `APP=app-mento`. Runtime code expects **`APP_NAME`**. Ensure `.env` contains `APP_NAME=...` or verification and routing will not work.
+
+## Core selection and URLs
+
+| Variable              | Description                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `ENV`                 | `prod`, `qa`, or effectively `custom` when using a custom base URL                    |
+| `CUSTOM_URL`          | When set, selects custom web base URL behavior (see `envHelper.getBaseWebUrl()`)      |
+| `CHAIN_NAME`          | e.g. `Celo`, `Monad` — combined with `IS_MAINNET` to resolve RPC, chain id, etc.      |
+| `IS_FORK`             | When true, use fork RPC URLs (e.g. `http://localhost:8545`) from `magicStrings.chain` |
+| `SPECS_TYPE`          | `web`, `api`, or other values handled by `spec-selector` (default web-like behavior)  |
+| `SPECS_REGEX`         | Comma-separated list joined with `\|` for Playwright `grep`                           |
+| `EXCLUDE_SPECS_REGEX` | Optional invert grep pattern                                                          |
+| `SPECS_DIR`           | Subdirectory under the app’s spec root (e.g. focus a folder)                          |
+
+## Execution tuning
+
+| Variable           | Description                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| `TEST_RETRY`       | Retries per test locally; in CI, retry behavior is forced to **1** in `config.helper` |
+| `TEST_RUN_TIMEOUT` | Global test run timeout (wired via `timeouts` constants / config)                     |
+| `TEST_TIMEOUT`     | Per-test timeout                                                                      |
+| `IS_PARALLEL_RUN`  | Enables parallel mode; optional `WORKERS_COUNT`                                       |
+| `LOG_LEVEL`        | log4js level: `ALL`, `TRACE`, `INFO`, `DEBUG`, etc.                                   |
+
+## Governance API (when testing governance API / env)
+
+| Variable                                                    | Description              |
+| ----------------------------------------------------------- | ------------------------ |
+| `GOVERNANCE_TESTNET_API_KEY` / `GOVERNANCE_TESTNET_API_URL` | QA testnet GraphQL / API |
+| `GOVERNANCE_MAINNET_API_KEY` / `GOVERNANCE_MAINNET_API_URL` | Mainnet (when used)      |
+
+`env.helper` chooses keys based on `IS_MAINNET`.
+
+## Reporting
+
+| Variable                     | Description                                               |
+| ---------------------------- | --------------------------------------------------------- |
+| `TESTOMAT_REPORT_GENERATION` | `true` / `false` — append Testomat reporter               |
+| `TESTOMAT_API_KEY`           | Testomat project API key                                  |
+| `TESTOMATIO_TITLE`           | Run title (CI may append actor and timestamp)             |
+| `HTML_REPORT_NAME`           | Subfolder name under `artifacts/reports/` for HTML output |
+
+## CI-only
+
+| Variable | Description                                                                      |
+| -------- | -------------------------------------------------------------------------------- |
+| `CI`     | Set by GitHub Actions; used for retries, reporters, fork Makefile branches, etc. |
+
+## Where URLs and chain IDs live
+
+Static **base URLs** per app and environment, **chain metadata**, and **governance** addresses/ABI references live in `src/constants/magic-strings.constants.ts`. Prefer changing that file (or env) rather than hardcoding URLs in specs.

--- a/docs/fork-and-local-chain.md
+++ b/docs/fork-and-local-chain.md
@@ -1,0 +1,48 @@
+# Fork and local chain
+
+Fork mode lets you run the same specs against **Anvil** at `http://localhost:8545` instead of public RPCs, with deterministic state and no real spend.
+
+## Flags and env
+
+- Set **`IS_FORK=true`** in `.env`.
+- Use **`IS_MAINNET`** together with fork helpers to choose **mainnet vs testnet** fork profiles (see `magicStrings.chain.*.fork`).
+- **`SEED_PHRASE`** (and wallet password) must still be valid for the forked state.
+
+## Makefile targets
+
+| Target                                              | Behavior                                                                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `make mainnet-fork-setup`                           | Start Anvil (mainnet fork) in background, wait, optionally start **Otterscan** (Docker) unless `CI=true`, run `pnpm run fork:prepare-data` |
+| `make testnet-fork-setup`                           | Same for testnet fork URL                                                                                                                  |
+| `make mainnet-fork-only` / `make testnet-fork-only` | Anvil only, foreground                                                                                                                     |
+| `make block-explorer-only`                          | Otterscan only                                                                                                                             |
+| `make stop-all-services`                            | Kill `anvil` processes and stop/remove Otterscan container                                                                                 |
+
+The Makefile invokes **`npm run fork:*`** scripts; the repo’s primary package manager is **pnpm**, but those scripts map to the same `package.json` entries.
+
+## `pnpm` scripts related to forks
+
+| Script                                       | Command role                                                               |
+| -------------------------------------------- | -------------------------------------------------------------------------- |
+| `fork:mainnet`                               | `anvil --fork-url https://forno.celo.org --port 8545`                      |
+| `fork:testnet`                               | `anvil --fork-url https://forno.celo-sepolia.celo-testnet.org --port 8545` |
+| `fork:prepare-data`                          | Runs `src/tools/prepare-fork-data.tool.ts`                                 |
+| `blockexplorer:start` / `blockexplorer:stop` | Docker Otterscan against local RPC                                         |
+
+## Prepare fork data
+
+`src/tools/prepare-fork-data.tool.ts` calls **`forkHelper.reportPrices()`** and **`forkHelper.setInitialBalances()`** (`src/helpers/fork/fork.helper.ts`) so accounts and oracles match what swap and governance tests expect.
+
+## CI fork path
+
+When **`IS_FORK`** is passed into `base-test.yml`, the **install** action can install **make** and **Foundry**, and the **setup** composite action runs the appropriate **`make *-fork-setup`** before **`pnpm run build:synpress-cache`** (with retries).
+
+## Synpress on forks
+
+After the fork is up and env points at `localhost:8545`, rebuild wallet cache:
+
+```bash
+pnpm run build:synpress-cache
+```
+
+Then run tests as usual (`pnpm run test`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,45 @@
+# Getting started
+
+## Prerequisites
+
+- **Node.js** ≥ 22.14.0
+- **pnpm** (version pinned in `package.json` under `packageManager`)
+- **Playwright browsers**: after install, run `pnpm run install:playwright`
+- **Foundry** (optional): for fork testing — includes `anvil` ([Foundry book](https://book.getfoundry.sh/getting-started/installation))
+- **Docker** (optional): local block explorer (Otterscan) used with some Makefile flows
+
+## Install
+
+```bash
+pnpm install
+```
+
+`postinstall` runs `src/tools/default-env-vars.tool.ts`, which creates a **`.env`** file from `src/constants/default-env-variables.constants.ts` if one does not exist.
+
+## Required local configuration
+
+1. Set **`SEED_PHRASE`** and **`WALLET_PASSWORD`** for MetaMask / Synpress flows.
+2. Set **`IS_MAINNET`** (`true` / `false`) to match the chain you test against. **Rebuild the Synpress cache** when changing this (`pnpm run build:synpress-cache`).
+3. Set **`APP_NAME`** to `app-mento`, `governance`, or `squid-router` (must match what `verify-env-config` and the assembler expect — see [Environment variables](environment-variables.md) for the template vs runtime names).
+
+Then:
+
+```bash
+pnpm run build:synpress-cache
+pnpm run test
+```
+
+## Common commands
+
+| Command                      | Use                                                     |
+| ---------------------------- | ------------------------------------------------------- |
+| `pnpm run test`              | Default Playwright run (runs `verify:env-config` first) |
+| `pnpm t`                     | Alias for `pnpm run test`                               |
+| `pnpm run test:ui`           | Playwright UI mode                                      |
+| `pnpm run test:debug`        | Playwright debug                                        |
+| `pnpm run verify:code`       | `tsc` + ESLint                                          |
+| `pnpm run verify:env-config` | Validates critical env vars before tests                |
+
+## CI parity
+
+GitHub Actions uses the **Playwright** Docker image version aligned with `@playwright/test` in `package.json` and `base-test.yml`. Keep these in sync when upgrading Playwright.

--- a/docs/glossary-and-conventions.md
+++ b/docs/glossary-and-conventions.md
@@ -1,0 +1,36 @@
+# Glossary and conventions
+
+## Application names (`APP_NAME`)
+
+| Value          | Product                             |
+| -------------- | ----------------------------------- |
+| `app-mento`    | Mento dApp (swap, wallet, settings) |
+| `governance`   | Mento Governance UI + API           |
+| `squid-router` | Squid Router integration surface    |
+
+Enum: `src/constants/apps.constants.ts` (`AppName`).
+
+## Chains (`CHAIN_NAME` + `IS_MAINNET`)
+
+- **`CHAIN_NAME`**: e.g. `Celo`, `Monad`.
+- **`IS_MAINNET`**: when `false`, `envHelper` maps logical chain to testnets (e.g. Celo → Celo Sepolia) for RPC and chain id.
+
+Fork mode overlays **localhost** RPC from `magicStrings.chain.*.fork`.
+
+## Playwright tags vs grep
+
+- Suite / test metadata may add tags like **`@smoke`** or **`@regression`** (composed in `test.helper`).
+- **`SPECS_REGEX`** and PR healthcheck patterns ultimately become Playwright **`grep`** / **`grepInvert`** — they are **regular expressions**, not only literal file names.
+
+## Test naming and files
+
+- Spec files: `*.spec.ts` under `specs/`.
+- Prefer **describe + test** structure using `testHelper` for shared setup and skip logic.
+
+## Secrets vs env vars
+
+In GitHub Actions, repository **secrets** are mapped to **process env** names expected by the framework (e.g. `E2E_TEST_SEED_PHRASE` → `SEED_PHRASE`). See [CI and GitHub Actions](ci-github-actions.md).
+
+## TypeScript strictness
+
+The project does **not** yet enable full `strict` mode in `tsconfig.json`. A future migration should tackle optional fixture typing, `WebApp` unions, `catch` error typing, and `null` initialization patterns across services. See [CONTRIBUTING](../CONTRIBUTING.md).

--- a/docs/logging-and-reporting.md
+++ b/docs/logging-and-reporting.md
@@ -1,0 +1,33 @@
+# Logging and reporting
+
+## Application logging (log4js)
+
+`src/helpers/logger/logger.helper.ts` exposes structured logs used across helpers and tools. **`LOG_LEVEL`** in `.env` controls verbosity (`ALL`, `TRACE`, `INFO`, `DEBUG`, …).
+
+Decorators under `src/decorators/` can attach logging behavior to selected methods.
+
+## Playwright reporters
+
+`src/helpers/config/config.helper.ts` builds the reporter list:
+
+1. **HTML** — always configured; output folder is  
+   `artifacts/reports/<HTML_REPORT_NAME>/`  
+   Default name: `playwright-report` if `HTML_REPORT_NAME` is unset.
+2. **List** — terminal list reporter for CI readability.
+3. **Testomat** — appended when **`TESTOMAT_REPORT_GENERATION`** is truthy **and** `TESTOMAT_API_KEY` is available. Locally, a default `TESTOMATIO_TITLE` may be synthesized with a timestamp.
+
+## CI HTML artifacts
+
+`base-test.yml` uploads the HTML report folder with **`actions/upload-artifact`** when generation is `true` or `onFailure` (input `HTML_REPORT_GENERATION`).
+
+## Cloud report (`report.yml`)
+
+On failure (or when configured), the **report** workflow downloads the artifact, authenticates to **Google Cloud** with `GCP_SA_KEY` / `E2E_TEST_GCP_SA_KEY`, and uploads to bucket **`mento-playwright-reports`**. The job output **`url`** is passed into Discord notifications.
+
+## Traces
+
+`playwright.config.ts` sets `use.trace` to **`retain-on-failure`**, so failed tests retain trace zip under the configured `outputDir` (`artifacts/test-results` via `magicStrings`).
+
+## ESLint (Playwright plugin)
+
+`eslint-plugin-playwright` is enabled for recommended rules (e.g. discouraging `page.pause()` in committed code, flagging some `force: true` clicks). Warnings may appear until flows are tightened.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,34 @@
+# Overview
+
+## Purpose
+
+This repository is the **test automation** codebase for executing automated checks against:
+
+- **Mento web app** (`app-mento`) — swap, wallet, settings, amounts, network
+- **Mento governance** (`governance`) — proposals, voting, locks, links
+- **Squid Router** (`squid-router`) — wallet and swap flows
+
+Tests target deployed environments (production, QA, or custom URLs) and optionally **local forks** of Celo (or related chains) via Anvil for deterministic, low-cost runs.
+
+## Technology stack
+
+| Layer           | Technology                                                                                    |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| Runtime         | Node.js ≥ 22.14 (see `package.json` `engines`)                                                |
+| Package manager | pnpm 10.x (`packageManager` field)                                                            |
+| Test runner     | Playwright (`@playwright/test`, pinned with CI Docker image)                                  |
+| Wallet E2E      | Synpress (`@synthetixio/synpress`) + MetaMask fixtures                                        |
+| Language        | TypeScript (ES modules, `moduleResolution: bundler`)                                          |
+| Lint / format   | ESLint 8, Prettier, Husky + lint-staged + pretty-quick                                        |
+| On-chain / APIs | ethers v5, viem, `@celo/contractkit`, Hardhat (tooling), optional Foundry **anvil** for forks |
+| Reporting       | Playwright HTML reporter; optional Testomat (`@testomatio/reporter`)                          |
+
+## How tests are organized
+
+- **Specs** live under `specs/<app>/web/` or `specs/<app>/api/` and are selected by `APP_NAME`, `SPECS_TYPE`, and optional `SPECS_REGEX` / `SPECS_DIR` (see [Running tests](running-tests.md)).
+- **Implementation** (pages, services, helpers, contracts) lives under `src/` and is composed at runtime by the **assembler** and Playwright **fixtures** (see [Test architecture](test-architecture.md)).
+
+## External references
+
+- High-level process and ownership may be described in internal docs (e.g. Notion — linked from the root README).
+- Application URLs and chain defaults are centralized in `src/constants/magic-strings.constants.ts` (see [Environment variables](environment-variables.md)).

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,0 +1,67 @@
+# Project structure
+
+## Top-level layout
+
+| Path                   | Purpose                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| `specs/`               | Playwright spec files, grouped by **app** then `web` or `api`                     |
+| `src/`                 | Framework code: apps, helpers, fixtures, constants, tools                         |
+| `src/wallet-setups/`   | Synpress wallet setup (e.g. `basic.setup.ts`)                                     |
+| `artifacts/`           | Test output: reports, screenshots, traces (see `.gitignore`)                      |
+| `.github/`             | Actions workflows, reusable workflows, composite actions, Dependabot, PR template |
+| `playwright.config.ts` | Playwright entry: timeouts, grep, projects, reporters                             |
+| `tsconfig.json`        | TypeScript options and **path aliases**                                           |
+| `Makefile`             | Fork + block explorer orchestration for local runs                                |
+| `docs/`                | This documentation set                                                            |
+
+## Specs layout
+
+```
+specs/
+├── app-mento/
+│   ├── web/          # UI tests for app.mento.org (and qa/custom)
+│   └── api/          # API-focused specs if present
+├── governance/
+│   ├── web/
+│   └── api/
+└── squid-router/
+    ├── web/
+    └── api/
+```
+
+Physical paths are mirrored in `magicStrings.path` (`appMento`, `governance`, `squidRouter`) and selected by `APP_NAME` + `SPECS_TYPE` in `spec-selector.helper.ts`.
+
+## `src/` layout (high level)
+
+| Path                     | Purpose                                                                |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `src/apps/app-mento/`    | Pages and services for Mento swap app                                  |
+| `src/apps/governance/`   | Governance UI + API wrappers                                           |
+| `src/apps/squid-router/` | Squid Router UI                                                        |
+| `src/apps/shared/`       | Shared pages, services, elements, contracts                            |
+| `src/helpers/`           | Browser, env, URL, waiter, contract, logger, test runner helpers, etc. |
+| `src/fixtures/`          | Playwright fixture extensions (`test.fixture.ts`)                      |
+| `src/constants/`         | Apps enum, tokens, timeouts, magic strings, default `.env` template    |
+| `src/decorators/`        | Logging decorators                                                     |
+| `src/tools/`             | CLI-style scripts invoked from `package.json`                          |
+
+## TypeScript path aliases
+
+Defined in `tsconfig.json` `compilerOptions.paths`:
+
+| Alias              | Maps to                               |
+| ------------------ | ------------------------------------- |
+| `@shared/*`        | `src/apps/shared/*`                   |
+| `@api/*`           | `src/application/api/*`               |
+| `@services/*`      | `src/application/web/services/*`      |
+| `@page-objects/*`  | `src/application/web/page-objects/*`  |
+| `@page-elements/*` | `src/application/web/page-elements/*` |
+| `@helpers/*`       | `src/helpers/*`                       |
+| `@constants/*`     | `src/constants/*`                     |
+| `@fixtures/*`      | `src/fixtures/*`                      |
+| `@magic-strings/*` | `src/magic-strings/*`                 |
+| `@decorators/*`    | `src/decorators/*`                    |
+
+`playwright.config.ts` imports via these aliases; keep new modules under paths that match existing conventions.
+
+**Note:** Aliases such as `@api/*`, `@services/*`, `@page-objects/*`, and `@page-elements/*` point at `src/application/...` directories that are **not** present in the current tree (reserved or legacy layout). Active code primarily uses `@shared/*`, `@helpers/*`, `@constants/*`, `@fixtures/*`, and `@decorators/*`.

--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -1,0 +1,52 @@
+# Running tests
+
+## npm / pnpm scripts
+
+| Script                                   | Behavior                                                                             |
+| ---------------------------------------- | ------------------------------------------------------------------------------------ |
+| `pnpm run test`                          | `verify:env-config` then `playwright test`                                           |
+| `pnpm t`                                 | Same as `pnpm run test`                                                              |
+| `pnpm run test:ui`                       | Playwright UI mode                                                                   |
+| `pnpm run test:debug`                    | Playwright inspector / debug                                                         |
+| `pnpm run install:playwright`            | `playwright install --with-deps`                                                     |
+| `pnpm run build:synpress-cache`          | Build Synpress wallet cache from `src/wallet-setups`                                 |
+| `pnpm run verify:code`                   | Typecheck + ESLint (used in Husky pre-commit and CI validate step)                   |
+| `pnpm run verify:env-config`             | Required env sanity check                                                            |
+| `pnpm run linter` / `pnpm run lint`      | ESLint over `*.ts` in the repo                                                       |
+| `pnpm run fork:mainnet` / `fork:testnet` | Start Anvil against public RPC (see [Fork and local chain](fork-and-local-chain.md)) |
+| `pnpm run calculate:swap-tests-costs`    | Offline tool: estimate balances for swap test matrix (ethers + mento-sdk)            |
+
+## Selecting specs
+
+Playwright config (`playwright.config.ts`) delegates to **`specSelectorHelper`**:
+
+- **`grep`** — from `SPECS_REGEX`: comma-separated tokens become a **regex** (`a,b` → `a|b`). If `SPECS_REGEX` is empty, all specs match (`.*`).
+- **`grepInvert`** — optional `EXCLUDE_SPECS_REGEX` with the same comma → `|` rule.
+- **`testDir`** — derived from `APP_NAME`, `SPECS_TYPE`, and optional `SPECS_DIR`.
+
+So you can filter by **file name fragment**, **test title** substring, or **`@tag`** if your suite uses Playwright tags (see `test.helper` / `composeTags`).
+
+## Timeouts
+
+`src/constants/timeouts.constants.ts` exposes:
+
+- **`timeouts.test`** — default test timeout (overridable with `TEST_TIMEOUT` ms string)
+- **`timeouts.testRun`** — global run cap (`TEST_RUN_TIMEOUT`, default large window)
+- Named tiers (`xs`, `m`, `xl`, …) for waits in page objects and helpers
+
+## Parallelism and workers
+
+- **`IS_PARALLEL_RUN`** — when truthy, `configHelper.isParallelRun()` enables `fullyParallel` and allows **`WORKERS_COUNT`** to set worker count; otherwise workers default to **1** for stability in wallet-heavy flows.
+
+## Retries
+
+- Locally: **`TEST_RETRY`** number is used (via `configHelper.getTestRetry()`).
+- In CI (`envHelper.isCI()`): retries are forced to **1** regardless of `TEST_RETRY`.
+
+## Headed vs headless
+
+Use Playwright defaults from config plus CLI flags, e.g. `pnpm exec playwright test --headed`.
+
+## Traces and artifacts
+
+Config sets `trace: "retain-on-failure"` and `outputDir` under `artifacts/test-results`. HTML reports go under `artifacts/reports/<HTML_REPORT_NAME>/` when the HTML reporter is enabled.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -1,0 +1,55 @@
+# Test architecture
+
+## Playwright fixtures
+
+`src/fixtures/test.fixture.ts` extends Synpress’s MetaMask fixtures and registers:
+
+- **`metamaskHelper`** — wraps Synpress `metamask` for flows and assertions
+- **`contractHelper`** — on-chain / contract interactions (`ContractHelper`)
+- **`web`** — full **web** stack: browser, pages, services for the current `APP_NAME`
+- **`api`** — HTTP + GraphQL clients and app-specific API surface
+
+The exported **`testFixture`** and **`expect`** are what specs and `test.helper` use instead of raw `@playwright/test` in wallet flows.
+
+## Assembler (factory)
+
+`src/helpers/assembler/assembler.helper.ts` builds either a **web** graph or an **api** graph depending on constructor dependencies:
+
+- **Web path:** `ElementFinderHelper`, `BrowserHelper`, `MetamaskHelper`, `ContractHelper`
+- **API path:** `HttpClient`, `GraphQLClient`
+
+The active application is determined by **`envHelper.getApp()`** (`APP_NAME`). Each app exposes a different shape under `web.app` (e.g. `appMento`, `governance`, `squidRouter`) — TypeScript models these as a **union** (`WebApp`), so specs that touch `web.app.appMento` are only valid when `APP_NAME` is `app-mento`.
+
+## Test suite helper
+
+`src/helpers/test/test.helper.ts` wraps `testFixture.describe` / `test` / `skip`:
+
+- **`runSuite`** — suite name, tags, optional `beforeAll` / `afterAll` (API-only context), `beforeEach` / `afterEach`, retry config, and a list of **`ITest`** cases
+- **`runTest`** — single test with optional **disable** conditions (`IDisable`) keyed by env or chain
+- **`skipInRuntime`** — dynamic skip with annotations
+
+Types live in `src/helpers/test/test.types.ts` (`IExecution`, `ITest`, `ISuiteArgs`, …).
+
+## Page objects, services, elements
+
+Typical pattern:
+
+- **`*Page`** — locators and simple interactions tied to a route or component
+- **`*Service`** — user flows calling pages, MetaMask, and browser helpers
+- **Elements** (`src/apps/shared/web/elements/`) — reusable controls (buttons, inputs, dropdowns) with shared base behavior
+
+Shared cross-app pieces (e.g. connect wallet modal, Celoscan links) live under **`src/apps/shared/`**.
+
+## Contracts
+
+`src/apps/shared/contracts/` contains helpers such as **`base.contract.ts`** and **`governance.contract.ts`** for interacting with deployed contracts during tests (proposals, execution, etc.).
+
+## Synpress cache
+
+Wallet extension state is built with:
+
+```bash
+pnpm run build:synpress-cache
+```
+
+This must be re-run when **`IS_MAINNET`** or fork-related chain configuration changes materially, so MetaMask and dApp chain IDs stay aligned.

--- a/docs/tools-and-scripts.md
+++ b/docs/tools-and-scripts.md
@@ -1,0 +1,28 @@
+# Tools and scripts
+
+## `package.json` scripts
+
+See [Running tests](running-tests.md) for the main test commands. Additional maintenance entries:
+
+| Script        | Implementation                                                                         |
+| ------------- | -------------------------------------------------------------------------------------- |
+| `postinstall` | `tsx src/tools/default-env-vars.tool.ts` — create `.env` if missing                    |
+| `prepare`     | `husky install`                                                                        |
+| `lint:staged` | Runs **lint-staged** (configured in `package.json` to `eslint --fix` on staged `*.ts`) |
+
+## `src/tools/`
+
+| File                                 | Purpose                                                                                                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default-env-vars.tool.ts`           | Writes default `.env` from `defaultEnvVariables` constant if file absent                                                                                      |
+| `verify-env-config.tool.ts`          | Exits non-zero if required wallet / app / chain flags missing                                                                                                 |
+| `prepare-fork-data.tool.ts`          | Fork bootstrap: prices + balances via `forkHelper`                                                                                                            |
+| `calculate-swap-tests-costs.tool.ts` | CLI (`yargs-parser`) to estimate **CELO / stable** needs for swap suites using **ethers** + **`@mento-protocol/mento-sdk`**; supports `--chain` / `--chainId` |
+
+## Husky
+
+`.husky/pre-commit` runs **pretty-quick** on staged files and **`pnpm run verify:code`**.
+
+## Cost calculator details
+
+`calculate-swap-tests-costs` reads trading pairs and suite configuration from repo constants, simulates or queries Mento contracts per chain, and prints a breakdown for **swap-by-token-pairs**, amount-type swaps, slippage scenarios, and a configurable **high-frequency** count (`DAILY_CONFIG` in source). Use it when onboarding new tokens or chains to ensure test wallets remain funded.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,35 @@
+# Troubleshooting
+
+## `verify:env-config` fails immediately
+
+- Confirm **`SEED_PHRASE`**, **`WALLET_PASSWORD`**, **`IS_MAINNET`**, and **`APP_NAME`** are set and non-empty.
+- If you only see **`APP=`** in `.env`, add **`APP_NAME=app-mento`** (or the correct app). Runtime code reads **`APP_NAME`**, not `APP`.
+
+## MetaMask or dApp shows the wrong network
+
+- Re-run **`pnpm run build:synpress-cache`** after changing **`IS_MAINNET`**, **`CHAIN_NAME`**, or fork settings.
+- For forks, ensure Anvil is listening on **`8545`** and **`IS_FORK=true`**.
+
+## Playwright cannot find specs
+
+- Check **`SPECS_TYPE`** (`web` vs `api`) and **`APP_NAME`** match the directory you expect under `specs/`.
+- **`SPECS_REGEX`**: commas become alternation; include **`@tag`** if you filter by tag.
+
+## CI passes locally but fails in GitHub Actions
+
+- Compare **Node** and **Playwright** versions with the workflow container image.
+- CI forces **test retries** to **1**; flaky tests may need hardening rather than higher local `TEST_RETRY`.
+
+## Fork / Makefile issues on macOS
+
+- Docker must be running for Otterscan targets.
+- **`make stop-all-services`** uses `pkill` on `anvil`; confirm no other Anvil instances hold the port.
+
+## ESLint warnings from `eslint-plugin-playwright`
+
+- **`playwright/no-force-option`**: prefer fixing underlying actionability; suppress only with a narrow inline comment if intentional.
+- **`playwright/no-page-pause`**: remove `page.pause()` before merge.
+
+## Report upload failures
+
+- Verify **`E2E_TEST_GCP_SA_KEY`** (JSON) is valid and the bucket policy allows the CI service account to write **`mento-playwright-reports`**.


### PR DESCRIPTION
### Description

This pull request adds a **documentation hub** under `docs/` so contributors can find setup, architecture, CI, environment variables, fork/local-chain workflows, logging/reporting, tooling, glossary, troubleshooting, and extended contributing guidance in one place. The root README now points to that index and to a dedicated contributing file, so onboarding and day-to-day reference do not depend on tribal knowledge or scattered notes.

**Current behavior:** The repository relied primarily on the root README (prerequisites, install, high-level test commands) and linked Notion for a broader automation overview. There was no in-repo index of technical topics (fixtures, workflows, `.env` semantics, PR healthcheck commit-message tags, Synpress/anvil details, etc.).

**Updated / expected behavior:** New and returning contributors can start from [docs/README.md](docs/README.md), follow topic-specific pages (overview, getting started, env vars, project structure, test architecture, running tests, CI, fork/local chain, logging, tools, glossary, troubleshooting, contributing), and use [CONTRIBUTING.md](CONTRIBUTING.md) for GitHub-facing PR healthcheck rules and housekeeping notes. The root README remains the short entry point but explicitly links into this structure.

### Other changes

- **README:** Added a “Documentation” table linking to `docs/README.md` and `CONTRIBUTING.md`; tightened the “headed” / default CLI wording (`pnpm run test` / `pnpm t`) for clarity.
- **CONTRIBUTING.md (new):** Short GitHub-facing guide covering PR healthcheck app tags and spec patterns, `pnpm run verify:code`, the note about TypeScript `strict` and a staged migration, and Dependabot / Playwright version alignment—without duplicating the longer narrative in `docs/contributing.md`.

### Checklist before requesting a review

- [ ] Performed a self-review of my own code
- [ ] PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] Tests passed locally
- [ ] Tests passed on the CI
- [ ] Test cases status updated to "automated" in the TMS

### Related issues

- Fixes # an issue number
